### PR TITLE
content(home): refresh About Me for AI Engineer (HR-ready)

### DIFF
--- a/prd/progress.md
+++ b/prd/progress.md
@@ -1,22 +1,21 @@
-# {{Project Name}} - Progress Tracker
+# Portfolio v3 - Progress Tracker
 
-*Last Updated: {{date}} (Brief update note)*
+*Last Updated: 2026-07-16 (About Me refreshed for AI Engineer / HR-ready positioning)*
 
 ---
 
 ## 🎯 Project Overview
-**Goal:** {{Project goal and purpose}}
-**Timeline:** {{Timeline with key milestones}}
-**Success Criteria:** {{Measurable success criteria}}
+**Goal:** Keep public portfolio copy aligned with current career (AI Engineer) so recruiters see accurate positioning on first scroll.
+**Success Criteria:** About + Intro no longer mention undergraduate status; copy reflects Sarana AI role, LLM/RAG/MCP stack, and UMM graduate credentials.
 
 ---
 
 ## 📊 Progress Summary
 
-### Overall Status: {{X}}% Complete
-- **{{Milestone 1}}**: ✅ **COMPLETED** - {{Brief accomplishment}}
-- **{{Milestone 2}}**: {{Status}} - {{Brief accomplishment}}
-- **{{Milestone 3}}**: {{Status}} - {{Brief accomplishment}}
+### Overall Status: 100% Complete (About Me refresh)
+- **About section copy**: ✅ **COMPLETED** - Replaced undergraduate/web-mobile description with AI Engineer @ Sarana AI copy
+- **Intro hero bio**: ✅ **COMPLETED** - Aligned bio and roles with production AI / full-stack positioning
+- **Ship**: ✅ **COMPLETED** - Commit, push, and open PR
 
 ---
 
@@ -24,94 +23,39 @@
 
 ### ✅ **COMPLETED** Features
 
-#### {{Feature Category 1}}
-- ✅ **{{Sub-feature}}** - {{Implementation status}}
-  - {{Technical details}}
-  - {{Key components}}
+#### About Me (HR-ready AI Engineer)
+- ✅ **About section description** - COMPLETED (2026-07-16)
+  - Removed “I am still an undergraduate” and web/mobile/UI-UX-only framing
+  - New copy: AI Engineer at Sarana AI, production LLM/RAG/MCP/AWS, Next.js/Go/Python, UMM Informatics Cum Laude 3.91/4.00
+  - File: `src/app/_components/about/index.tsx`
+- ✅ **Intro hero bio + roles** - COMPLETED (2026-07-16)
+  - Bio now leads with LLMs, RAG, MCP, Sarana AI, Python/AWS/Next.js/Go
+  - Roles: `AI Engineer`, `Cloud Enthusiast`, `Full-Stack Builder` (replaced `DevOps Learner`)
+  - File: `src/app/_components/intro/index.tsx`
 
-#### {{Feature Category 2}}
-- ✅ **{{Sub-feature}}** - {{Implementation status}}
-  - {{Technical details}}
-  - {{Key components}}
-
-### 🚧 **IN PROGRESS** Features
-
-#### {{Feature Category}}
-- ⏳ **{{Sub-feature}}** - {{Current status}}
-  - {{What's working}}
-  - {{Remaining work}}
-
-### 📋 **TODO** Features
-
-#### {{Feature Category}}
-- ❌ **{{Sub-feature}}** - {{Priority level}}
-  - {{Requirements}}
-  - {{Dependencies}}
+### 📋 **Out of scope (unchanged)**
+- Supabase career/education rows (DB-backed)
+- Owner-profile API `about` field
+- Footer / terminal / metadata (already AI Engineer)
 
 ---
 
 ## 🔧 Technical Implementation Notes
 
 ### Key Code Locations
-- **{{Feature}}:** {{File paths}}
-- **{{Integration}}:** {{File paths}}
-- **{{Utility}}:** {{File paths}}
+- **About section:** `src/app/_components/about/index.tsx`
+- **Intro section:** `src/app/_components/intro/index.tsx`
+- **Home wiring:** `src/app/page.tsx`
 
-### Environment Variables Required
-- {{Environment variable}} - {{Status}}
-- {{Environment variable}} - {{Status}}
-- {{Environment variable}} - {{Status}}
-
----
-
-## 🎯 Demo/Testing Requirements
-
-### Target Demo Sequence
-1. {{Step 1}}
-2. {{Step 2}}
-3. {{Step 3}}
-4. {{Step 4}}
-
-### Success Metrics
-- ✅ **{{Metric 1}}** - {{Status}}
-- ⏳ **{{Metric 2}}** - {{Status}}
-- ❌ **{{Metric 3}}** - {{Status}}
-
----
-
-## 🧱 Productionization TODO Backlog
-
-### High Priority (Post-Demo/MVP)
-- **{{Task category}}**
-  - {{Specific task}}
-  - {{Specific task}}
-  - {{Specific task}}
-
-### Medium Priority (Post-MVP)
-- **{{Task category}}**
-  - {{Specific task}}
-  - {{Specific task}}
-
-### Lower Priority (Scale)
-- **{{Task category}}**
-  - {{Specific task}}
-  - {{Specific task}}
+### Source of truth for copy
+- Public LinkedIn: https://www.linkedin.com/in/rizkyhaksono
 
 ---
 
 ## 🧠 Development Notes
 
 ### Architecture Decisions Made
-- **{{Decision}}:** {{Rationale}}
-- **{{Decision}}:** {{Rationale}}
-
-### Recent Technical Challenges
-- **{{Challenge}}:** {{Solution approach}}
-- **{{Challenge}}:** {{Solution approach}}
-
-### Testing Strategy
-- {{Testing approach}}
-- {{Testing coverage status}}
-- {{Critical test cases}}
+- **Copy-only change:** No layout/visual redesign; `SectionHeading` already supports longer descriptions.
+- **English copy:** Matches rest of portfolio and LinkedIn for tech recruiter scanning.
 
 ---

--- a/src/app/_components/about/index.tsx
+++ b/src/app/_components/about/index.tsx
@@ -16,7 +16,7 @@ export default function AboutSection() {
           eyebrow="About"
           title="A little"
           accent="about me"
-          description="Experience in Software Development with skills in Web and Mobile Development. I am still an undergraduate and have experience related to web and mobile development as well as UI/UX design."
+          description="AI Engineer at Sarana AI building production LLM systems — RAG/embeddings, MCP integrations, and cloud-native agents on AWS. I ship end-to-end products with Next.js, Go, and Python that cut manual work and scale real business workflows. Informatics graduate from Universitas Muhammadiyah Malang (Cum Laude, 3.91/4.00)."
         />
         <div className="mt-6 flex flex-wrap gap-3">
           <Button asChild size="sm">

--- a/src/app/_components/intro/index.tsx
+++ b/src/app/_components/intro/index.tsx
@@ -11,7 +11,7 @@ import { media_socials } from "@/commons/constants/contact"
 import { ArrowRight } from "lucide-react"
 import type { OwnerProfile } from "@/services/visitor/owner-profile"
 
-const roles = ["AI Engineer", "Cloud Enthusiast", "DevOps Learner"]
+const roles = ["AI Engineer", "Cloud Enthusiast", "Full-Stack Builder"]
 
 const HERO_STATS = [
   { label: "Focus", value: "AI Engineer" },
@@ -59,8 +59,8 @@ export default function IntroSection({ profile }: Readonly<{ profile?: OwnerProf
           {/* Bio Text */}
           <div className="animate-fade-in-up" style={{ animationDelay: "300ms" }}>
             <p className="max-w-xl text-xs sm:text-sm leading-relaxed text-muted-foreground">
-              Passionate about <span className="font-medium text-foreground">web, mobile, cloud, and DevOps development</span>. I build <Typography.Em>innovative</Typography.Em> solutions with{" "}
-              <span className="font-medium text-foreground">React, Next.js, TypeScript</span>, and more — focused on high-performance applications and clean CI/CD pipelines.
+              Building production AI systems — <span className="font-medium text-foreground">LLMs, RAG, and MCP</span> — backed by full-stack and cloud engineering. At Sarana AI I ship scalable agents and data platforms with{" "}
+              <span className="font-medium text-foreground">Python, AWS, Next.js, and Go</span>, focused on reliable CI/CD and <Typography.Em>measurable</Typography.Em> impact.
             </p>
           </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Refresh the home About and Intro copy so recruiters see current AI Engineer positioning instead of outdated undergraduate language.

## Why

The About section still said “I am still an undergraduate” and focused on web/mobile/UI-UX, while the public LinkedIn profile shows Greenfield AI Engineer @ Sarana AI and an Informatics graduate (Cum Laude, 3.91/4.00). Intro roles said AI Engineer but the bio still led with web/mobile/DevOps.

## Changes

- Replace About section description with Sarana AI / LLM / RAG / MCP / AWS + UMM graduate copy (`src/app/_components/about/index.tsx`)
- Align Intro hero bio with production AI systems and stack signals (Python, AWS, Next.js, Go)
- Update typing roles: `DevOps Learner` → `Full-Stack Builder`
- Update `prd/progress.md` with this About Me refresh tracking

## Out of scope

- Supabase career/education rows
- Owner-profile API `about` field
- Footer / terminal / metadata (already AI Engineer)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6c8c-5ce9-7cde-ac4a-24f4f4f97054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6c8c-5ce9-7cde-ac4a-24f4f4f97054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

