### PR TITLE
Unify UI layout surfaces and encode design system in agent rules

### DIFF
--- a/.cursor/rules/agents-index.mdc
+++ b/.cursor/rules/agents-index.mdc
@@ -1,0 +1,35 @@
+---
+description: Index of AI agent instruction files and UI docs for Portfolio v3.
+alwaysApply: true
+---
+
+# Agent Instructions Index
+
+Canonical entry: **`AGENTS.md`** (repo root).
+
+| Platform | File |
+|---|---|
+| All agents | `AGENTS.md` |
+| Claude | `CLAUDE.md` + `.claude/` |
+| Cursor | `.cursorrules` + `.cursor/rules/*.mdc` |
+| Gemini | `.geminirules` + `GEMINI.md` |
+| Copilot | `.github/copilot-instructions.md` |
+
+## UI documentation
+
+Human-readable design system (required reading for UI work):
+
+- `docs/ui/README.md` — index
+- `docs/ui/design-system.md` — tokens
+- `docs/ui/surfaces.md` — solid / glass / inset
+- `docs/ui/page-shell.md` — BaseLayout recipes
+- `docs/ui/components.md` — primitive catalog
+- `docs/ui/platforms.md` — visitor / user / admin / auth
+
+Enforced rule: `.cursor/rules/ui-layout-consistency.mdc`  
+Tokens: `src/lib/design-system.ts`
+
+## Progress tracking
+
+- Read `prd/feature.md` then `prd/progress.md` before feature work
+- Update `prd/progress.md` after completing tasks

--- a/.cursor/rules/nextjs-development.mdc
+++ b/.cursor/rules/nextjs-development.mdc
@@ -13,7 +13,8 @@ You are an expert full-stack TypeScript engineer working with Next.js. Produce p
 - **TypeScript** (strict mode)
 - **Testing**: Vitest + React Testing Library + MSW
 - **Styling**: Tailwind CSS + shadcn/ui (when applicable)
-- **Package Manager**: pnpm
+- **Package Manager**: npm
+- **UI layout**: See `.cursor/rules/ui-layout-consistency.mdc` — solid / glass / inset surfaces only; use `PageBody`, `PageSection`, `Surface`, `MacWindow`, `SectionHeading`
 
 Focus on: separation of concerns, strict typing, accessibility, performance, and comprehensive testing.
 

--- a/.cursor/rules/ui-layout-consistency.mdc
+++ b/.cursor/rules/ui-layout-consistency.mdc
@@ -1,0 +1,86 @@
+---
+description: UI layout & surface design system for Portfolio v3. Enforce consistent boxes, sections, and page shells.
+globs: ["src/**/*.{tsx,ts,css}", "tailwind.config.ts"]
+alwaysApply: true
+---
+
+# UI Layout & Surface Consistency
+
+Portfolio v3 uses a **monochrome, square, hairline-border** design language. Keep every new UI on this system.
+
+## Tokens (source of truth)
+
+- CSS variables in `src/app/globals.css` (semantic colors only: `background`, `foreground`, `card`, `border`, `muted`, `primary`, …)
+- Radius: all named radii collapse to `0` in `tailwind.config.ts` (square). Keep `rounded-full` only for avatars/dots.
+- Shared class tokens: `src/lib/design-system.ts` (`SURFACE`, `PAGE_WIDTH`, `SECTION_SPACING`)
+
+**Never** use raw palette classes like `neutral-*`, `text-black`, hex hovers (`#262626`, `#D9D9D9`), or `border-white/10` glass stacks on content cards.
+
+## Three surface dialects only
+
+| Variant | Use for | Primitive |
+|---|---|---|
+| **solid** | Content boxes, lists, feature/platform cards | `Card`, `FeatureCard`, `Surface variant="solid"` |
+| **glass** | Window chrome only (title bar + frosted shell) | `MacWindow`, `Surface variant="glass"` / `glass-static` |
+| **inset** | Nested rows, sidebar blocks, status cells | `Surface variant="inset"` |
+
+### Forbidden on content cards
+
+Do **not** invent glass content cards:
+
+```
+border-white/10 bg-white/5 backdrop-blur-md hover:shadow-xl hover:-translate-y-1
+```
+
+Use solid + `hover:border-foreground/20` instead.
+
+## Page shell recipe (visitor / user)
+
+```
+BaseLayout(sidebar?, rightSidebar?)
+  └─ PageBody width="default" | "prose" | "article" | "wide"
+       └─ SectionHeading (as="h1" on page routes)
+       └─ MacWindow? (tools / lists) OR Card / FeatureCard / Surface rows
+```
+
+- Prefer `PageSection` for home/page blocks (`mt-10` + optional `SectionHeading`).
+- Prefer `PageBody` for width — do **not** stack extra `px-4 lg:px-0` inside BaseLayout (container already pads).
+- Do not invent `max-w-8xl` (undefined). Use `PAGE_WIDTH` presets.
+
+## Heading & micro-UI
+
+- Section titles: always `SectionHeading` (eyebrow + display title + optional serif italic accent).
+- Labels/tags: `Eyebrow`, `Chip`.
+- Stat rows: `StatStrip`.
+
+## Media / list cards
+
+Blog and project cards share the solid Card pattern:
+
+- `hover:border-foreground/20` (not `hover:border-primary/40` + lift shadows)
+- Footer: `p-4 … border-t border-border`
+- Do not restate `border border-border bg-card shadow-sm` on Card (already defaults)
+
+## MacWindow
+
+- Default body pad: `p-4 sm:p-6`
+- Drag-and-drop pages (tracker): `backdrop={false}` — do **not** copy-paste Mac chrome markup
+- Glass is for chrome only; put solid cards *inside* the window
+
+## Admin shell
+
+Admin keeps its own sidebar/header layout, but still uses solid `Card` / `Surface` / `SectionHeading` — no third card dialect (`border-border/50` raw divs → `Surface` or `Card`).
+
+## Outliers (do not copy)
+
+- `/signal` — standalone marketing experiment
+- `terminal-overlay` — intentional dark terminal chrome
+
+## Checklist before shipping UI
+
+- [ ] Used `Card` / `FeatureCard` / `Surface` / `MacWindow` — no ad-hoc bordered box
+- [ ] No glass classes on content cards
+- [ ] No extra horizontal padding inside BaseLayout
+- [ ] Width via `PageBody` when a max-width is needed
+- [ ] Section titles via `SectionHeading`
+- [ ] Colors from semantic tokens only

--- a/.cursorrules
+++ b/.cursorrules
@@ -4,7 +4,7 @@ You are an expert full-stack TypeScript engineer working on this Next.js project
 
 ## Core Directives
 
-1. **Always refer to the specific rules in `.cursor/rules/*.mdc`** for detailed, up-to-date guidelines on Next.js development, project management, and unit testing within this project.
+1. **Always refer to the specific rules in `.cursor/rules/*.mdc`** for detailed, up-to-date guidelines (Next.js, project management, unit testing, **UI layout consistency**).
 2. Note that this project uses multiple AI assistants. For AI-specific instructions, refer to their respective configurations:
    - **Cursor**: `.cursor/rules/*.mdc`
    - **Claude**: `CLAUDE.md` and `.claude/` directory
@@ -17,5 +17,21 @@ You are an expert full-stack TypeScript engineer working on this Next.js project
 
 - **React Server Components (RSC):** Default to Server Components. Add `'use client'` only when hook/state/browser interactivity is necessary.
 - **Components:** Avoid inline styling. Rely wholly on Tailwind UI utilities and `cn()` from `@/lib/utils`.
-- **Architecture:** `app/` is for routes and layouts. `components/ui/` is for resuable Shadcn widgets. `components/[feature]/` handles localized logic. Extricate reusable hook logic out to `lib/` or `hooks/`.
+- **Architecture:** `app/` is for routes and layouts. `components/ui/` is for reusable Shadcn widgets. `components/[feature]/` handles localized logic. Extricate reusable hook logic out to `lib/` or `hooks/`.
 - **Quality:** Keep functions modular, readable, and typed. Do not rely on `any`.
+
+## UI Layout (mandatory)
+
+Monochrome, square, hairline borders. Three surface dialects only — see `.cursor/rules/ui-layout-consistency.mdc` and `src/lib/design-system.ts`:
+
+| Dialect | Primitive | Use |
+|---|---|---|
+| solid | `Card` / `FeatureCard` / `Surface` | Content boxes |
+| glass | `MacWindow` / `Surface variant="glass"` | Window chrome only |
+| inset | `Surface variant="inset"` | Nested rows / sidebar blocks |
+
+- Page shell: `BaseLayout` → `PageBody` → `SectionHeading` → content
+- Sections: `PageSection` (`mt-10` rhythm)
+- Never invent glass content cards (`bg-white/5`, `backdrop-blur-md`, lift shadows)
+- Prefer semantic color tokens; ban `neutral-*` / raw hex for UI chrome
+- Do not add extra `px-*` inside BaseLayout (container already pads)

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,15 +1,20 @@
 # Cursor Rules for Portfolio v3
 
+> Canonical cross-agent instructions: [`AGENTS.md`](./AGENTS.md)  
+> UI design system: [`docs/ui/README.md`](./docs/ui/README.md)
+
 You are an expert full-stack TypeScript engineer working on this Next.js project. Produce production-ready code that follows modern Next.js App Router patterns and best practices.
 
 ## Core Directives
 
-1. **Always refer to the specific rules in `.cursor/rules/*.mdc`** for detailed, up-to-date guidelines (Next.js, project management, unit testing, **UI layout consistency**).
-2. Note that this project uses multiple AI assistants. For AI-specific instructions, refer to their respective configurations:
-   - **Cursor**: `.cursor/rules/*.mdc`
-   - **Claude**: `CLAUDE.md` and `.claude/` directory
-   - **Gemini**: `.geminirules`
+1. **Always refer to** [`AGENTS.md`](./AGENTS.md) and `.cursor/rules/*.mdc` (Next.js, project management, unit testing, **UI layout consistency**).
+2. Platform instruction map:
+   - **All agents**: `AGENTS.md`
+   - **Cursor**: `.cursorrules` + `.cursor/rules/*.mdc`
+   - **Claude**: `CLAUDE.md` + `.claude/`
+   - **Gemini**: `.geminirules` / `GEMINI.md`
    - **Copilot**: `.github/copilot-instructions.md`
+   - **UI docs**: `docs/ui/`
 3. Adhere strictly to the Next.js 15+ App Router, TypeScript (strict mode), Tailwind CSS, and shadcn/ui.
 4. Use **npm** as the standard package manager.
 
@@ -17,12 +22,13 @@ You are an expert full-stack TypeScript engineer working on this Next.js project
 
 - **React Server Components (RSC):** Default to Server Components. Add `'use client'` only when hook/state/browser interactivity is necessary.
 - **Components:** Avoid inline styling. Rely wholly on Tailwind UI utilities and `cn()` from `@/lib/utils`.
-- **Architecture:** `app/` is for routes and layouts. `components/ui/` is for reusable Shadcn widgets. `components/[feature]/` handles localized logic. Extricate reusable hook logic out to `lib/` or `hooks/`.
+- **Architecture:** `app/` is for routes and layouts. `components/ui/` is for reusable Shadcn widgets. Feature logic in `components/[feature]/` or `app/_components/`. Extricate reusable hook logic to `lib/` or `hooks/`.
 - **Quality:** Keep functions modular, readable, and typed. Do not rely on `any`.
+- **Progress:** Read/update `prd/feature.md` and `prd/progress.md` for tracked work.
 
 ## UI Layout (mandatory)
 
-Monochrome, square, hairline borders. Three surface dialects only — see `.cursor/rules/ui-layout-consistency.mdc` and `src/lib/design-system.ts`:
+Monochrome, square, hairline borders. Three surface dialects only — see `.cursor/rules/ui-layout-consistency.mdc`, [`docs/ui/`](./docs/ui/), and `src/lib/design-system.ts`:
 
 | Dialect | Primitive | Use |
 |---|---|---|
@@ -35,3 +41,5 @@ Monochrome, square, hairline borders. Three surface dialects only — see `.curs
 - Never invent glass content cards (`bg-white/5`, `backdrop-blur-md`, lift shadows)
 - Prefer semantic color tokens; ban `neutral-*` / raw hex for UI chrome
 - Do not add extra `px-*` inside BaseLayout (container already pads)
+
+Platform shells (visitor / user / admin / auth): [`docs/ui/platforms.md`](./docs/ui/platforms.md)

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,8 +1,33 @@
 version = 1
 
+test_patterns = [
+  "**/*.test.ts",
+  "**/*.test.tsx",
+  "**/*.spec.ts",
+  "**/*.spec.tsx",
+  "**/__tests__/**",
+  "**/__mocks__/**",
+]
+
+exclude_patterns = [
+  "node_modules/**",
+  ".next/**",
+  "out/**",
+  "coverage/**",
+  "public/**",
+  "content/**",
+  "docs/**",
+  "**/*.d.ts",
+]
+
 [[analyzers]]
 name = "javascript"
+enabled = true
 
   [analyzers.meta]
   plugins = ["react"]
-  environment = ["nodejs"]
+  environment = ["nodejs", "browser"]
+  dialect = "typescript"
+  module_system = "es-modules"
+  # React components are usually arrow/function expressions; require docs on declarations instead.
+  skip_doc_coverage = ["arrow-function-expression", "function-expression", "method-definition"]

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -29,5 +29,5 @@ enabled = true
   environment = ["nodejs", "browser"]
   dialect = "typescript"
   module_system = "es-modules"
-  # React components are usually arrow/function expressions; require docs on declarations instead.
-  skip_doc_coverage = ["arrow-function-expression", "function-expression", "method-definition"]
+  # Match existing DeepSource dashboard setting used on main.
+  skip_doc_coverage = ["arrow-function-expression"]

--- a/.geminirules
+++ b/.geminirules
@@ -29,6 +29,20 @@ You are an expert full-stack TypeScript engineer working on this Next.js project
    - Maintain mobile-first responsive design.
 6. **Code Quality:** Keep functions small. Abstract complex or repetitive logic into hooks or `lib/`. Do not write superfluous comments. Let variables and function names document themselves.
 
+## UI Layout Consistency (mandatory)
+
+Monochrome, square, hairline borders. See `.cursor/rules/ui-layout-consistency.mdc` and `src/lib/design-system.ts`.
+
+Surfaces (only three):
+
+- solid → `Card` / `FeatureCard` / `Surface`
+- glass → `MacWindow` (chrome only)
+- inset → `Surface variant="inset"`
+
+Page shell: `BaseLayout` → `PageBody` → `SectionHeading` → content.
+
+Never invent glass content cards or extra padding inside BaseLayout. Prefer `PageSection` for `mt-10` blocks.
+
 ## Development Workflow
 
 - When asked to add or modify a feature, ensure you analyze existing architecture and patterns before writing code.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,8 @@
 # GitHub Copilot Instructions
 
+> Canonical cross-agent instructions: [`AGENTS.md`](../AGENTS.md)  
+> UI design system: [`docs/ui/README.md`](../docs/ui/README.md)
+
 You are an expert full-stack TypeScript engineer working on this Next.js project. Produce production-ready code that follows modern Next.js App Router patterns and best practices.
 
 ## Tech Stack
@@ -7,25 +10,31 @@ You are an expert full-stack TypeScript engineer working on this Next.js project
 - **Next.js 15+** (App Router) + React 19
 - **TypeScript** (strict mode)
 - **Styling**: Tailwind CSS + shadcn/ui
+- **Testing**: Vitest + React Testing Library + MSW
 - **Package Manager**: npm
 
 ## Architectural Guidelines
 
-1. **React Server Components (RSC):** Default to Server Components. Add `'use client'` only at the top of files that require state, hooks, interactivity, or browser APIs.
-2. **Component Organization:**
+1. Prefer [`AGENTS.md`](../AGENTS.md) as the shared source of truth across AI platforms.
+2. **React Server Components (RSC):** Default to Server Components. Add `'use client'` only at the top of files that require state, hooks, interactivity, or browser APIs.
+3. **Component Organization:**
    - Pages and layouts go in `app/`.
    - Reusable UI elements go in `components/ui/`.
-   - Feature-specific code goes in `components/[feature]/`.
-3. **TypeScript:** Use explicit `interface` or `type` for all props and state. Avoid using `any` completely.
-4. **Styling (Tailwind & shadcn/ui):**
+   - Feature-specific code goes in `components/[feature]/` or `app/_components/`.
+4. **TypeScript:** Use explicit `interface` or `type` for all props and state. Avoid using `any` completely.
+5. **Styling (Tailwind & shadcn/ui):**
    - Rely solely on Tailwind utility classes.
    - Use the `cn()` utility from `@/lib/utils` for conditional class merging.
    - Ensure a mobile-first responsive design.
-5. **Code Quality:** Keep functions small. Abstract complex logic into hooks or utility functions in `lib/`. Avoid superfluous comments. Let the variable and function names self-document the code.
+6. **Code Quality:** Keep functions small. Abstract complex logic into hooks or utility functions in `lib/`. Avoid superfluous comments. Let the variable and function names self-document the code.
 
 ## UI Layout Consistency (mandatory)
 
-Monochrome, square, hairline borders. Tokens live in `src/lib/design-system.ts`. Full rule: `.cursor/rules/ui-layout-consistency.mdc`.
+Monochrome, square, hairline borders.
+
+- Docs: [`docs/ui/README.md`](../docs/ui/README.md)
+- Tokens: `src/lib/design-system.ts`
+- Rule: `.cursor/rules/ui-layout-consistency.mdc`
 
 Use only:
 
@@ -37,8 +46,12 @@ Page recipe: `BaseLayout` → `PageBody` → `SectionHeading` → content.
 
 Do not create glass content cards (`bg-white/5`, `backdrop-blur-md`, lift shadows) or add extra `px-*` inside BaseLayout. Prefer `PageSection` for section spacing.
 
+Platform shells (visitor / user / admin / auth): [`docs/ui/platforms.md`](../docs/ui/platforms.md).
+
 ## Behavior
 
 - Always consider the existing project architecture before suggesting big changes.
+- Read/update `prd/feature.md` and `prd/progress.md` for tracked work.
 - Prioritize making code accessible (ARIA roles, keyboard navigation).
 - Ensure error handling is robust (use early returns to fail fast).
+- Run `npx tsc --noEmit` before claiming completion.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,20 @@ You are an expert full-stack TypeScript engineer working on this Next.js project
    - Ensure a mobile-first responsive design.
 5. **Code Quality:** Keep functions small. Abstract complex logic into hooks or utility functions in `lib/`. Avoid superfluous comments. Let the variable and function names self-document the code.
 
+## UI Layout Consistency (mandatory)
+
+Monochrome, square, hairline borders. Tokens live in `src/lib/design-system.ts`. Full rule: `.cursor/rules/ui-layout-consistency.mdc`.
+
+Use only:
+
+- **solid** — `Card`, `FeatureCard`, `Surface` for content
+- **glass** — `MacWindow` for window chrome only
+- **inset** — `Surface variant="inset"` for nested rows
+
+Page recipe: `BaseLayout` → `PageBody` → `SectionHeading` → content.
+
+Do not create glass content cards (`bg-white/5`, `backdrop-blur-md`, lift shadows) or add extra `px-*` inside BaseLayout. Prefer `PageSection` for section spacing.
+
 ## Behavior
 
 - Always consider the existing project architecture before suggesting big changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,105 @@
+# AGENTS.md — Portfolio v3
+
+Canonical instructions for **any** coding agent working in this repository (Cursor, Claude, Codex, Gemini, Copilot, and others). Platform-specific files may add tooling notes; when they conflict, prefer this file plus `.cursor/rules/*.mdc`.
+
+You are an expert full-stack TypeScript engineer. Produce production-ready code that follows modern Next.js App Router patterns and best practices.
+
+## Tech Stack
+
+- **Next.js 15+** (App Router) + React 19
+- **TypeScript** (strict mode)
+- **Styling**: Tailwind CSS + shadcn/ui
+- **Testing**: Vitest + React Testing Library + MSW
+- **Package Manager**: npm
+
+## AI Instruction Map
+
+| Platform | Entry file | Extra |
+|---|---|---|
+| **All agents** | `AGENTS.md` (this file) | — |
+| **Claude** | `CLAUDE.md` | `.claude/` |
+| **Cursor** | `.cursorrules` | `.cursor/rules/*.mdc` |
+| **Gemini** | `.geminirules` | — |
+| **Copilot** | `.github/copilot-instructions.md` | — |
+| **UI system** | `docs/ui/README.md` | `src/lib/design-system.ts` |
+
+Always read `prd/feature.md` and `prd/progress.md` before starting feature work; update `prd/progress.md` after completing tasks.
+
+## Architectural Guidelines
+
+1. **React Server Components (RSC):** Default to Server Components. Add `'use client'` only at the top of files requiring state, hooks, interactivity, or browser APIs.
+2. **Component Organization:**
+   - Routes belong in `app/`.
+   - Reusable UI elements belong in `components/ui/`.
+   - Feature-specific code belongs in `components/[feature]/` or `app/_components/`.
+3. **TypeScript:** Use explicit `interface` or `type` for all props and state. Avoid `any`.
+4. **Styling:**
+   - Use Tailwind utility classes only (no inline styles unless unavoidable).
+   - Use `cn()` from `@/lib/utils` for conditional class merging.
+   - Mobile-first responsive design.
+5. **Code Quality:** Keep functions small. Abstract complex or repetitive logic into hooks or `lib/`. No superfluous comments — names should be self-documenting.
+6. **Package manager:** Use **npm** (not pnpm/bun/yarn) unless the user explicitly overrides.
+
+## UI Layout Consistency (mandatory)
+
+Design language: **monochrome, square (radius 0), hairline borders**.
+
+- Full agent rule: `.cursor/rules/ui-layout-consistency.mdc`
+- Human docs: [`docs/ui/README.md`](docs/ui/README.md)
+- Tokens: [`src/lib/design-system.ts`](src/lib/design-system.ts)
+
+### Three surface dialects only
+
+1. **solid** — `Card`, `FeatureCard`, `Surface variant="solid"` for content boxes
+2. **glass** — `MacWindow` / `Surface variant="glass"` for window chrome only
+3. **inset** — `Surface variant="inset"` for nested rows and sidebar blocks
+
+### Page recipe
+
+```
+BaseLayout(sidebar?, rightSidebar?)
+  └─ PageBody width="default" | "prose" | "article" | "wide"
+       └─ SectionHeading (as="h1" on page routes)
+       └─ MacWindow? (tools / lists) OR Card / FeatureCard / Surface rows
+```
+
+### Do not
+
+- Invent glass content cards (`border-white/10`, `bg-white/5`, `backdrop-blur-md`, `hover:-translate-y`)
+- Stack extra `px-4` / `lg:px-0` inside BaseLayout
+- Use `neutral-*`, raw hex, or `max-w-8xl` (undefined)
+- Copy-paste Mac chrome — use `MacWindow` (`backdrop={false}` when DnD needs it)
+
+### Prefer
+
+`PageSection`, `PageBody`, `SectionHeading`, `Eyebrow`, `Chip`, `StatStrip`, `Surface`, `Card`, `FeatureCard`, `MacWindow`
+
+## Shells by route group
+
+| Group | Shell | Surfaces |
+|---|---|---|
+| Visitor / home | `BaseLayout` | solid + MacWindow chrome |
+| User (profile, AI) | `BaseLayout` | solid |
+| Admin | Admin sidebar + top header | solid Card / Surface |
+| Auth | Centered form / split | solid Card |
+| Outliers | `/signal`, terminal overlay | do not copy |
+
+Details: [`docs/ui/platforms.md`](docs/ui/platforms.md)
+
+## Development Workflow
+
+1. Read `prd/feature.md` → `prd/progress.md` → existing patterns in code.
+2. Prefer primitives over ad-hoc bordered `div`s.
+3. Validate input at boundaries; fail fast; map errors cleanly.
+4. Keep UI accessible (labels, roles, keyboard navigation).
+5. Update `prd/progress.md` when a task is done.
+6. Run typecheck before claiming completion (`npx tsc --noEmit`).
+
+## Acceptance checklist (UI)
+
+- [ ] Used `Card` / `FeatureCard` / `Surface` / `MacWindow` — no ad-hoc bordered box
+- [ ] No glass classes on content cards
+- [ ] No extra horizontal padding inside BaseLayout
+- [ ] Width via `PageBody` when a max-width is needed
+- [ ] Section titles via `SectionHeading`
+- [ ] Colors from semantic tokens only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,27 @@ You are an expert full-stack TypeScript engineer working on this Next.js project
    - Maintain mobile-first responsive design.
 6. **Code Quality:** Keep functions small. Abstract complex or repetitive logic into hooks or `lib/`. Do not write superfluous comments. Let variable and function names document themselves.
 
+## UI Layout Consistency (mandatory)
+
+Design language: monochrome, square (radius 0), hairline borders. Full rules: `.cursor/rules/ui-layout-consistency.mdc`. Tokens: `src/lib/design-system.ts`.
+
+**Three surface dialects only:**
+
+1. **solid** — `Card`, `FeatureCard`, `Surface variant="solid"` for content boxes
+2. **glass** — `MacWindow` / `Surface variant="glass"` for window chrome only
+3. **inset** — `Surface variant="inset"` for nested rows and sidebar blocks
+
+**Page recipe:** `BaseLayout` → `PageBody` → `SectionHeading` → content (`MacWindow` for tools/lists, solid cards for content).
+
+**Do not:**
+
+- Invent glass content cards (`border-white/10`, `bg-white/5`, `backdrop-blur-md`, `hover:-translate-y`)
+- Stack extra `px-4` / `lg:px-0` inside BaseLayout
+- Use `neutral-*`, raw hex, or `max-w-8xl` (undefined)
+- Copy-paste Mac chrome — use `MacWindow` (`backdrop={false}` when DnD needs it)
+
+**Prefer:** `PageSection`, `PageBody`, `SectionHeading`, `Eyebrow`, `Chip`, `StatStrip`.
+
 ## Development Workflow
 
 - **When analyzing requirements:** Before modifying code, always look at existing patterns in the project (especially existing UI components or custom hooks).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
 # Claude Instructions for Portfolio v3
 
+> Canonical cross-agent instructions: [`AGENTS.md`](./AGENTS.md)  
+> UI design system: [`docs/ui/README.md`](./docs/ui/README.md)
+
 You are an expert full-stack TypeScript engineer working on this Next.js project. You must produce production-ready code that follows modern Next.js App Router patterns and best practices.
 
 ## Tech Stack
@@ -12,16 +15,18 @@ You are an expert full-stack TypeScript engineer working on this Next.js project
 
 ## Architectural Guidelines
 
-1. **AI Instruction Context (Multiple Agents):** Note that this project uses multiple AI assistants. For detailed rules and specific use-cases, refer to:
+1. **AI Instruction Context (Multiple Agents):** This project uses multiple AI assistants. Prefer [`AGENTS.md`](./AGENTS.md) as the shared source of truth. Platform files:
+   - **All agents**: `AGENTS.md`
    - **Claude**: `CLAUDE.md` and `.claude/` directory
    - **Cursor**: `.cursorrules` and `.cursor/rules/*.mdc`
-   - **Gemini**: `.geminirules`
+   - **Gemini**: `.geminirules` / `GEMINI.md`
    - **Copilot**: `.github/copilot-instructions.md`
+   - **UI docs**: `docs/ui/`
 2. **React Server Components (RSC):** Default to Server Components. Add `'use client'` only at the top of files requiring state, hooks, interactivity, or browser APIs.
 3. **Component Organization:**
    - Routes belong in `app/`.
    - Reusable UI elements belong in `components/ui/`.
-   - Feature-specific code belongs in `components/[feature]/`.
+   - Feature-specific code belongs in `components/[feature]/` or `app/_components/`.
 4. **TypeScript:** Use explicit `interface` or `type` for all props and state. Avoid using `any` completely.
 5. **Styling:**
    - Use Tailwind utility classes.
@@ -31,7 +36,11 @@ You are an expert full-stack TypeScript engineer working on this Next.js project
 
 ## UI Layout Consistency (mandatory)
 
-Design language: monochrome, square (radius 0), hairline borders. Full rules: `.cursor/rules/ui-layout-consistency.mdc`. Tokens: `src/lib/design-system.ts`.
+Design language: monochrome, square (radius 0), hairline borders.
+
+- Full agent rule: `.cursor/rules/ui-layout-consistency.mdc`
+- Docs: [`docs/ui/README.md`](./docs/ui/README.md)
+- Tokens: `src/lib/design-system.ts`
 
 **Three surface dialects only:**
 
@@ -50,8 +59,12 @@ Design language: monochrome, square (radius 0), hairline borders. Full rules: `.
 
 **Prefer:** `PageSection`, `PageBody`, `SectionHeading`, `Eyebrow`, `Chip`, `StatStrip`.
 
+Shells by platform: [`docs/ui/platforms.md`](./docs/ui/platforms.md).
+
 ## Development Workflow
 
-- **When analyzing requirements:** Before modifying code, always look at existing patterns in the project (especially existing UI components or custom hooks).
-- **Security & Error Handling:** Validate input at boundaries, and fail fast. Implement robust error handling strategies.
-- **Accessibility:** Make all UI enhancements accessible via keyboard nav and accurate ARIA attributes.
+- Read `prd/feature.md` and `prd/progress.md` before feature work; update progress after tasks.
+- Before modifying code, always look at existing patterns (especially UI primitives).
+- Validate input at boundaries; fail fast; robust error handling.
+- Make UI accessible via keyboard nav and accurate ARIA attributes.
+- Run `npx tsc --noEmit` before claiming completion.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,5 +1,7 @@
 # Gemini Instructions for Portfolio v3
 
+This file mirrors [`.geminirules`](./.geminirules) for tools that look for `GEMINI.md`.
+
 > Canonical cross-agent instructions: [`AGENTS.md`](./AGENTS.md)  
 > UI design system: [`docs/ui/README.md`](./docs/ui/README.md)
 

--- a/README.md
+++ b/README.md
@@ -445,12 +445,26 @@ For your specific schema, check Supabase dashboard or migration files.
 - Create custom styles in `globals.css` only when necessary
 - Leverage Shadcn/ui components for consistency
 - Use CSS modules for scoped styles if needed: `styles.module.css`
+- **UI layout system:** monochrome, square, hairline borders — see [`docs/ui/README.md`](./docs/ui/README.md) and `src/lib/design-system.ts` (solid / glass / inset surfaces only)
 
 ### Error Handling
 
 - Use Zod for schema validation
 - Create typed error responses
 - Log errors to monitoring service (Sentry, etc.)
+
+## AI Agents & UI Docs
+
+Shared instructions for coding agents and the UI design system:
+
+| Resource | Path |
+|---|---|
+| Canonical agent instructions | [`AGENTS.md`](./AGENTS.md) |
+| Claude | [`CLAUDE.md`](./CLAUDE.md) |
+| Cursor | [`.cursorrules`](./.cursorrules) + `.cursor/rules/` |
+| Gemini | [`.geminirules`](./.geminirules) / [`GEMINI.md`](./GEMINI.md) |
+| Copilot | [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) |
+| UI design system | [`docs/ui/README.md`](./docs/ui/README.md) |
 
 ## Troubleshooting
 

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -1,0 +1,27 @@
+# UI Design System — Portfolio v3
+
+Canonical documentation for layout, surfaces, and page shells. Agents should also follow [`AGENTS.md`](../AGENTS.md) and `.cursor/rules/ui-layout-consistency.mdc`.
+
+## Index
+
+| Doc | Purpose |
+|---|---|
+| [design-system.md](./design-system.md) | Tokens, typography, color, radius |
+| [surfaces.md](./surfaces.md) | solid / glass / inset dialects |
+| [page-shell.md](./page-shell.md) | BaseLayout, PageBody, PageSection recipes |
+| [components.md](./components.md) | Primitive catalog & when to use each |
+| [platforms.md](./platforms.md) | Visitor, user, admin, auth shells |
+
+## Quick rules
+
+1. Monochrome, square corners, hairline borders.
+2. Only three surface dialects: **solid**, **glass**, **inset**.
+3. Page recipe: `BaseLayout` → `PageBody` → `SectionHeading` → content.
+4. Tokens live in `src/lib/design-system.ts` and CSS vars in `src/app/globals.css`.
+
+## Source of truth (code)
+
+- Tokens: `src/lib/design-system.ts`
+- Primitives: `src/components/ui/{surface,page-body,page-section,mac-window,card,bento,section-heading}.tsx`
+- Shell: `src/components/layout/base-layout.tsx`
+- Agent rule: `.cursor/rules/ui-layout-consistency.mdc`

--- a/docs/ui/components.md
+++ b/docs/ui/components.md
@@ -1,0 +1,83 @@
+# UI Primitives Catalog
+
+Prefer these over ad-hoc bordered `div`s.
+
+## Layout & structure
+
+| Primitive | Path | Role |
+|---|---|---|
+| `BaseLayout` | `components/layout/base-layout.tsx` | Visitor/user page shell |
+| `PageBody` | `components/ui/page-body.tsx` | Content width preset |
+| `PageSection` | `components/ui/page-section.tsx` | `mt-10` section + optional heading |
+| `SectionHeading` | `components/ui/section-heading.tsx` | Eyebrow + title + accent + description |
+| `SidebarMain` / `SidebarSecondary` | `components/layout/` | Left nav |
+| `RightSidebarWindow` | `components/layout/right-sidebar-window.tsx` | Collapsible glass info panel |
+| `VisitorPanel` | `components/layout/visitor-panel.tsx` | IP / status / weather inset blocks |
+
+## Surfaces
+
+| Primitive | Path | Dialect |
+|---|---|---|
+| `Card` (+ Header/Content/Footer/Title/Description) | `components/ui/card.tsx` | solid |
+| `Surface` | `components/ui/surface.tsx` | solid / glass / glass-static / inset |
+| `FeatureCard` / `BentoGrid` | `components/ui/bento.tsx` | solid feature grid |
+| `MacWindow` | `components/ui/mac-window.tsx` | glass chrome |
+
+### Surface API
+
+```tsx
+<Surface variant="solid" | "glass" | "glass-static" | "inset" padding="none" | "default" | "compact" | "cozy">
+  …
+</Surface>
+```
+
+### MacWindow API
+
+```tsx
+<MacWindow title="~/tools" backdrop? bodyClassName?>
+  …
+</MacWindow>
+```
+
+- `backdrop` defaults to `true`. Set `false` for DnD pages (tracker).
+
+## Typography & chrome
+
+| Primitive | Role |
+|---|---|
+| `Eyebrow` | Small uppercase label |
+| `Chip` | Mono tag |
+| `StatStrip` | Horizontal hairline stats |
+| `Typography` | Legacy text helpers — prefer SectionHeading for titles |
+| `Button` | shadcn button variants |
+| `Badge` | Compact status |
+
+## Media / list cards
+
+| Component | Path | Notes |
+|---|---|---|
+| `CardBlog` | `app/_components/blog/card-blog.tsx` | solid + `hover:border-foreground/20` |
+| `CardBlogMedium` | `app/_components/blog/blog-medium.tsx` | same hover |
+| `CardProject` | `app/_components/project/card-project.tsx` | same hover |
+
+Footer pattern: `p-4 pt-4 mt-auto border-t border-border`.
+
+## When to pick what
+
+```
+Need a page shell?          → BaseLayout
+Need max-width?             → PageBody
+Need section spacing?       → PageSection
+Need a title block?         → SectionHeading
+Need a content box?         → Card or Surface solid
+Need a feature/platform tile? → FeatureCard or Surface solid + cozy pad
+Need tool/list chrome?      → MacWindow
+Need a nested row?          → Surface inset
+Need DnD inside a window?   → MacWindow backdrop={false}
+```
+
+## Outliers (do not copy)
+
+- `/signal` — standalone dark marketing
+- `terminal-overlay` — intentional dark terminal chrome
+- Admin login heavy shadows — keep contained to auth; do not spread to visitor UI

--- a/docs/ui/design-system.md
+++ b/docs/ui/design-system.md
@@ -1,0 +1,59 @@
+# Design System Tokens
+
+## Visual language
+
+- **Monochrome** — near-black on white (light) / near-white on near-black (dark). No accent hue.
+- **Square** — every named Tailwind radius collapses to `0` in `tailwind.config.ts`. Keep `rounded-full` only for avatars, status dots, and icon bubbles.
+- **Hairline borders** — use semantic `border` / `border-border` tokens, not heavy shadows or glow.
+
+## CSS variables
+
+Defined in `src/app/globals.css` (`:root` and `.dark`):
+
+| Token | Role |
+|---|---|
+| `--background` / `--foreground` | Page canvas + body text |
+| `--card` / `--card-foreground` | Solid content boxes |
+| `--primary` / `--primary-foreground` | Primary actions / emphasis |
+| `--secondary` / `--muted` / `--accent` | Soft fills and nests |
+| `--border` / `--input` / `--ring` | Hairlines and focus |
+| `--destructive` | Errors / danger only |
+| `--radius` | `0rem` (square) |
+
+Fonts (via layout / Tailwind):
+
+- `--font-sans` — body
+- `--font-display` — section titles
+- `--font-serif` — italic accent words in headings
+- `--font-mono` — chips, MacWindow titles, code
+
+## Shared class tokens
+
+Import from `@/lib/design-system`:
+
+```ts
+import { SURFACE, SURFACE_PADDING, SECTION_SPACING, PAGE_WIDTH } from "@/lib/design-system"
+```
+
+| Export | Keys | Use |
+|---|---|---|
+| `SURFACE` | `solid`, `solidHover`, `glass`, `glassNoBlur`, `inset` | Box chrome |
+| `SURFACE_PADDING` | `default` (`p-6`), `compact` (`p-4`), `cozy` (`p-5`) | Inner pad |
+| `SECTION_SPACING` | `section` (`mt-10`), `sectionGap` (`mt-6`) | Section rhythm |
+| `PAGE_WIDTH` | `default`, `prose`, `article`, `wide` | Max-width presets |
+
+## Forbidden patterns
+
+| Avoid | Prefer |
+|---|---|
+| `neutral-*`, `text-black`, `dark:text-white` | `foreground`, `muted-foreground` |
+| Hex hovers (`#262626`, `#D9D9D9`) | `accent`, `secondary`, `muted` |
+| `border-white/10 bg-white/5 backdrop-blur-md` on content | solid `Card` / `Surface` |
+| `hover:shadow-xl hover:-translate-y-1` on cards | `hover:border-foreground/20` |
+| `max-w-8xl` (undefined) | `PAGE_WIDTH` via `PageBody` |
+| Extra `px-4 lg:px-0` inside BaseLayout | Trust container padding |
+
+## Container
+
+Tailwind `container`: centered, `padding: 2rem`, `2xl: 1400px`.  
+`BaseLayout` uses `container` **without** stacking another horizontal `px-*`.

--- a/docs/ui/page-shell.md
+++ b/docs/ui/page-shell.md
@@ -1,0 +1,80 @@
+# Page Shell
+
+## Visitor / user recipe
+
+```
+BaseLayout(sidebar?, rightSidebar?, useGridBackground?, useInteractiveGrid?)
+  └─ PageBody width="default" | "prose" | "article" | "wide"
+       └─ SectionHeading as="h1" …
+       └─ MacWindow?  OR  Card / FeatureCard / Surface grid
+```
+
+### BaseLayout
+
+File: `src/components/layout/base-layout.tsx`
+
+- Applies Tailwind `container` + top padding.
+- Optional left `sidebar` and right `rightSidebar`.
+- Includes Navbar (mobile), Footer, ScrollProgress, optional grid background.
+- **Do not** add extra horizontal `px-4` / `lg:px-0` on children.
+
+### PageBody
+
+File: `src/components/ui/page-body.tsx`
+
+| `width` | Classes | When |
+|---|---|---|
+| `default` | `w-full` | Most pages inside BaseLayout |
+| `prose` | `max-w-3xl` | Long-form articles |
+| `article` | `max-w-5xl` | Project detail, changelog-like |
+| `wide` | `max-w-7xl` | Dense grids (stats, roadmap) |
+
+Always includes `flex flex-col gap-6`.
+
+### PageSection
+
+File: `src/components/ui/page-section.tsx`
+
+- Wrapper with `mt-10` rhythm.
+- Optional `heading` prop → renders `SectionHeading`.
+- Content gap `mt-6` when a heading is present.
+
+```tsx
+<PageSection
+  heading={{
+    eyebrow: "Education",
+    title: "Academic",
+    accent: "foundation",
+    description: "…",
+  }}
+>
+  <Surface variant="solid" padding="compact">…</Surface>
+</PageSection>
+```
+
+### SectionHeading
+
+File: `src/components/ui/section-heading.tsx`
+
+- Eyebrow + display title + optional serif italic `accent` + muted description.
+- Use `as="h1"` on page routes; `as="h2"` (default) for home sections.
+
+## Micro-UI
+
+| Component | Role |
+|---|---|
+| `Eyebrow` | Uppercase mono label |
+| `Chip` | Compact tag / duration |
+| `StatStrip` | Hairline grid of stats |
+
+## Width anti-patterns
+
+| Avoid | Prefer |
+|---|---|
+| Nested `max-w-6xl mx-auto px-4 lg:px-0` inside BaseLayout | `<PageBody width="wide">` |
+| `max-w-8xl` | Does not exist — use `wide` or `default` |
+| Double `container` on child pages | Trust BaseLayout |
+
+## Standalone pages
+
+Some routes intentionally skip BaseLayout (legal, changelog sticky header, `/signal`). Prefer joining BaseLayout over time, or document a dedicated standalone shell — do not invent a one-off padding dialect.

--- a/docs/ui/platforms.md
+++ b/docs/ui/platforms.md
@@ -1,0 +1,72 @@
+# Platform Shells
+
+How each route group should compose layout and surfaces.
+
+## Visitor (public portfolio)
+
+**Routes:** `/`, `/blog`, `/project`, `/certificates`, `/tools`, `/tracker`, `/status`, `/stats`, `/chat`, `/roadmap`, …
+
+**Shell:** `BaseLayout` + usually `SidebarMain`; some pages also mount `RightSidebarWindow` / `VisitorPanel`.
+
+**Surfaces:**
+
+- Page title → `SectionHeading as="h1"`
+- Tools / boards / lists → wrap in `MacWindow`
+- Content tiles → solid `Card` / `FeatureCard` / `Surface`
+- Nested rows (status, leetcode pills) → `Surface variant="inset"`
+
+**Examples:**
+
+| Page | Pattern |
+|---|---|
+| Home sections | `PageSection` + solid rows |
+| Blog / Project index | `MacWindow` + media Cards |
+| Stats | `PageBody width="wide"` + `MacWindow` + solid PlatformCards |
+| Tracker | `MacWindow backdrop={false}` + board |
+| Status | `MacWindow` + inset service rows |
+
+## User (authenticated)
+
+**Routes:** `/profile`, `/ai`, …
+
+**Shell:** `BaseLayout` + left sidebar.
+
+**Surfaces:** solid `Card` for profile header/content. No glass content cards. Prefer `PageBody` without inventing `max-w-8xl`.
+
+## Admin
+
+**Routes:** `/admin/dashboard/*`
+
+**Shell:** Admin expandable sidebar + top header (not `BaseLayout`). Main area uses `p-4 sm:p-5` offset layout.
+
+**Surfaces:** still solid only — `Card` / `Surface variant="solid"`. Page headers may use `SectionHeading` / `Eyebrow`. Do not invent a third dialect (`border-border/50` raw divs → `Surface` or `Card`).
+
+## Auth
+
+**Routes:** `/auth/*`, `/admin/auth/login`
+
+**Shell:** Pass-through / centered form. Often a solid `Card` with constrained `max-w-sm` / `max-w-md` / `max-w-3xl`.
+
+**Surfaces:** solid Card. Heavier shadows are acceptable here but must not leak into visitor UI.
+
+## Standalone / outliers
+
+| Route | Status | Guidance |
+|---|---|---|
+| `/legal/*` | Often no BaseLayout | Prefer joining BaseLayout or a documented standalone shell |
+| `/changelog` | Sticky custom header | Same |
+| `/signal` | Intentional dark marketing | Do not copy patterns elsewhere |
+| Terminal overlay | Dark chrome | Keep isolated |
+
+## Cross-platform agent docs
+
+All AI platforms share the same UI rules. Entry points:
+
+| Platform | File |
+|---|---|
+| All agents | [`AGENTS.md`](../../AGENTS.md) |
+| Claude | [`CLAUDE.md`](../../CLAUDE.md) |
+| Cursor | [`.cursorrules`](../../.cursorrules) + `.cursor/rules/` |
+| Gemini | [`.geminirules`](../../.geminirules) |
+| Copilot | [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md) |
+| UI docs | This folder (`docs/ui/`) |

--- a/docs/ui/surfaces.md
+++ b/docs/ui/surfaces.md
@@ -1,0 +1,69 @@
+# Surfaces
+
+Portfolio v3 allows **exactly three** surface dialects. Do not invent blends.
+
+## Dialect matrix
+
+| Variant | Visual | Primitive | Use for |
+|---|---|---|---|
+| **solid** | `border-border bg-card shadow-sm` | `Card`, `FeatureCard`, `Surface variant="solid"` | Content boxes, lists, feature/platform cards, media cards |
+| **glass** | `border-border/60 bg-background/40 backdrop-blur-sm` | `MacWindow`, `Surface variant="glass"` | Window chrome only (title bar + frosted shell) |
+| **glass-static** | glass without blur | `MacWindow backdrop={false}`, `Surface variant="glass-static"` | Same chrome when an ancestor filter breaks DnD / fixed positioning |
+| **inset** | `border-border/40 bg-secondary/20` | `Surface variant="inset"` | Nested rows, sidebar blocks, status cells |
+
+## Solid (default content)
+
+```tsx
+import { Card, CardContent } from "@/components/ui/card"
+import { Surface } from "@/components/ui/surface"
+import { FeatureCard } from "@/components/ui/bento"
+
+<Card className="hover:border-foreground/20">…</Card>
+<Surface variant="solid" padding="compact">…</Surface>
+<FeatureCard title="…" description="…">…</FeatureCard>
+```
+
+Hover standard for interactive solid cards: `hover:border-foreground/20`.  
+Do **not** restate `border border-border bg-card shadow-sm` on `Card` — already defaults.
+
+## Glass (chrome only)
+
+```tsx
+import { MacWindow } from "@/components/ui/mac-window"
+
+<MacWindow title="~/tools">{/* solid cards inside */}</MacWindow>
+<MacWindow title="~/tracker" backdrop={false}>{/* DnD board */}</MacWindow>
+```
+
+Glass wraps tools/lists. Put **solid** cards *inside* the window. Never make the content card itself glass.
+
+## Inset (nested)
+
+```tsx
+<Surface variant="inset" className="flex items-center justify-between px-4 py-3">
+  …
+</Surface>
+```
+
+Use for visitor-panel blocks, status rows, metric pills inside a larger solid/glass parent.
+
+## Forbidden glass content stack
+
+```
+border-white/10 dark:border-white/5
+bg-white/5 dark:bg-neutral-900/40
+backdrop-blur-md
+hover:shadow-xl hover:-translate-y-1
+```
+
+Replace with solid + `hover:border-foreground/20`.
+
+## Padding guide
+
+| Context | Padding |
+|---|---|
+| Default Card Header/Content | `p-6` / `p-6 pt-0` |
+| Compact rows / education / feedback | `p-4` (`Surface padding="compact"`) |
+| Platform / cozier cards | `p-5` (`padding="cozy"`) |
+| MacWindow body | `p-4 sm:p-6` (override only when needed) |
+| Media card footer | `p-4` + `border-t border-border` |

--- a/prd/feature.md
+++ b/prd/feature.md
@@ -1,158 +1,35 @@
-Got it — here’s your **agent-optimized PRD template in Markdown (`.md`)** so you can reuse it for any product:
-
-````markdown
-# PRD — [Product Name] MVP
+# PRD — UI Layout Consistency
 
 ## 1. Overview
-[One-paragraph description of the product. Include key functionality, user interactions, and constraints like onboarding or payment.]
-
----
+Unify Portfolio v3 UI so all boxes, sections, and page shells share one monochrome square design language. Encode the system in shared primitives and AI agent rules so future changes stay consistent.
 
 ## 2. System Goals
-- [Goal 1: core outcome]
-- [Goal 2: workflows to automate or improve]
-- [Goal 3: monetization / business value]
+- One surface scale: solid (content), glass (window chrome), inset (nested rows)
+- Shared page recipe: BaseLayout → PageBody → SectionHeading → content
+- Eliminate ad-hoc glass cards, double padding, and undefined max-widths
+- Document rules for Cursor, Claude, Gemini, and Copilot
 
----
+## 3. Features
 
-## 3. Entities & Schemas
+### 3.1 Design tokens
+- `src/lib/design-system.ts` exports `SURFACE`, `PAGE_WIDTH`, `SECTION_SPACING`
 
-### Example: `users`
-```sql
-create table users (
-  id uuid primary key default gen_random_uuid(),
-  email text unique not null,
-  phone text unique,
-  created_at timestamptz default now()
-);
-````
+### 3.2 Primitives
+- `Surface` — solid / glass / glass-static / inset
+- `PageSection` — mt-10 + optional SectionHeading
+- `PageBody` — width presets (default / prose / article / wide)
+- `MacWindow.backdrop` — disable blur for DnD pages
 
-### Example: `subscriptions`
+### 3.3 Migrations
+- Glass content cards (stats, duolingo, monkeytype, spotify) → solid
+- Raw bordered divs → Surface / Card
+- Media card hover unified to `hover:border-foreground/20`
+- BaseLayout padding fix (container only)
 
-```sql
-create table subscriptions (
-  id uuid primary key default gen_random_uuid(),
-  user_id uuid references users(id),
-  stripe_customer_id text,
-  stripe_subscription_id text,
-  status text check (status in ('active','canceled','past_due')),
-  created_at timestamptz default now()
-);
-```
+### 3.4 Agent rules
+- `.cursor/rules/ui-layout-consistency.mdc` (always apply)
+- Sync `.cursorrules`, `CLAUDE.md`, `.geminirules`, `.github/copilot-instructions.md`
 
-\[Add more entities as needed: `messages`, `tasks`, `reminders`, etc.]
-
----
-
-## 4. Features
-
-### 4.1 Onboarding & Payment
-
-* **Signup:** \[Auth provider]
-* **Phone Verification:**
-
-  * Input: `{ phone_number }`
-  * Output: `{ success: true, otp_sent: true }`
-* **Payment:** Stripe/PayPal/etc → subscription sync
-
-### 4.2 Channels / Interfaces
-
-#### Web Chat
-
-* Input: `{ user_id, message }`
-* Output: `{ status: "stored", assistant_reply }`
-* Flow:
-
-  1. Store in DB
-  2. Call LLM agent with context
-  3. Save + return assistant reply
-
-#### SMS (Twilio example)
-
-* Input:
-
-  ```json
-  { "From": "+12025550123", "To": "+12025550999", "Body": "Remind me tomorrow at 9am" }
-  ```
-* Output:
-
-  ```json
-  { "status": "stored", "thread_id": "thread_123", "task_created": true }
-  ```
-
-#### Email
-
-* Inbound: \[Webhook flow]
-* Outbound: \[Gmail API, SMTP, etc.]
-* Input: `{ from, to, subject, body }`
-* Output: `{ status: "sent", message_id }`
-
-### 4.3 Assistant Capabilities
-
-* **Calendar**
-
-  * Input: `{ action, title, time, attendees }`
-  * Output: `{ success: true, event_id }`
-* **Reminders**
-
-  * Input: `{ message, remind_at }`
-  * Output: `{ success: true, reminder_id }`
-* **Calls**
-
-  * Input: `{ to, message }`
-  * Output: `{ status: "call_placed", call_id }`
-* **Emails**
-
-  * Input: `{ to, subject, body }`
-  * Output: `{ success: true, email_id }`
-
----
-
-## 5. Integrations
-
-* \[Payment Provider]
-* \[Telephony Provider]
-* \[Calendar API]
-* \[Email API]
-* \[Other APIs]
-
----
-
-## 6. Architecture
-
-* **Frontend:** \[Framework/UI stack]
-* **Backend:** \[API services/functions]
-* **Database/Auth:** \[DB + Auth provider]
-* **Edge Functions:** \[Webhook handlers, background jobs]
-* **AI Layer:**
-
-  * Input: `{ thread_context, user_message }`
-  * Output: `{ intent, structured_command }`
-* **Execution Layer:** Maps structured command → service call
-
----
-
-## 7. Security
-
-* RLS or ACLs for user data
-* Encrypted tokens/secrets
-* Webhook signature verification
-
----
-
-## 8. Success Metrics
-
-* **Activation Rate**
-
-  ```sql
-  select count(*) from users u
-  where exists (select 1 from messages m where m.user_id = u.id);
-  ```
-* **Task Completion Rate**
-* **Engagement (DAU/WAU)**
-* **Retention**
-* **Revenue (MRR, ARR)**
-
----
-
-```
+## 4. Out of Scope
+- Full Signal page restyle (documented outlier)
+- Admin shell redesign (keep separate; reuse solid surfaces)

--- a/prd/progress.md
+++ b/prd/progress.md
@@ -1,117 +1,46 @@
-# {{Project Name}} - Progress Tracker
+# Portfolio v3 — UI Layout Consistency
 
-*Last Updated: {{date}} (Brief update note)*
-
----
-
-## 🎯 Project Overview
-**Goal:** {{Project goal and purpose}}
-**Timeline:** {{Timeline with key milestones}}
-**Success Criteria:** {{Measurable success criteria}}
+*Last Updated: 2026-07-16 — Unified surface dialects + AI rules*
 
 ---
 
-## 📊 Progress Summary
-
-### Overall Status: {{X}}% Complete
-- **{{Milestone 1}}**: ✅ **COMPLETED** - {{Brief accomplishment}}
-- **{{Milestone 2}}**: {{Status}} - {{Brief accomplishment}}
-- **{{Milestone 3}}**: {{Status}} - {{Brief accomplishment}}
+## Project Overview
+**Goal:** Make every visitor/user/admin content box use the same layout language (solid / glass / inset), and lock the pattern into Cursor/Claude/Gemini/Copilot rules so future work stays consistent.
+**Success Criteria:** No glass content cards; shared primitives used; AI instruction files document the system.
 
 ---
 
-## 🏗️ Feature Implementation Status
+## Progress Summary
 
-### ✅ **COMPLETED** Features
-
-#### {{Feature Category 1}}
-- ✅ **{{Sub-feature}}** - {{Implementation status}}
-  - {{Technical details}}
-  - {{Key components}}
-
-#### {{Feature Category 2}}
-- ✅ **{{Sub-feature}}** - {{Implementation status}}
-  - {{Technical details}}
-  - {{Key components}}
-
-### 🚧 **IN PROGRESS** Features
-
-#### {{Feature Category}}
-- ⏳ **{{Sub-feature}}** - {{Current status}}
-  - {{What's working}}
-  - {{Remaining work}}
-
-### 📋 **TODO** Features
-
-#### {{Feature Category}}
-- ❌ **{{Sub-feature}}** - {{Priority level}}
-  - {{Requirements}}
-  - {{Dependencies}}
+### Overall Status: 90% Complete
+- **Audit**: COMPLETED — mapped surface dialects and page-shell drift
+- **Primitives**: COMPLETED — `SURFACE` tokens, `Surface`, `PageSection`, `PageBody`, `MacWindow.backdrop`
+- **Migrations**: COMPLETED — glass stats/contrib cards → solid; education/visitor-panel/status/feedback → Surface; media card hover unified
+- **Rules**: COMPLETED — `.cursor/rules/ui-layout-consistency.mdc` + synced AI instruction files
+- **Remaining**: Optional — move stats/roadmap BaseLayout into `layout.tsx`; restyle legal/changelog onto BaseLayout; Signal stays outlier
 
 ---
 
-## 🔧 Technical Implementation Notes
+## Feature Implementation Status
 
-### Key Code Locations
-- **{{Feature}}:** {{File paths}}
-- **{{Integration}}:** {{File paths}}
-- **{{Utility}}:** {{File paths}}
+### COMPLETED
+- Design tokens module: `src/lib/design-system.ts`
+- Primitives: `surface.tsx`, `page-section.tsx`, `page-body.tsx`
+- BaseLayout: removed double horizontal padding
+- MacWindow: `backdrop` prop; tracker uses it instead of duplicated chrome
+- Migrated glass → solid: site-stats, duolingo, monkeytype, spotify
+- Migrated ad-hoc boxes → Surface: education, visitor-panel, status rows, leetcode section, admin feedback, stats PlatformCard
+- Media cards: blog / blog-medium / project hover → `hover:border-foreground/20`
+- Rules: Cursor / Claude / Gemini / Copilot / nextjs-development.mdc
 
-### Environment Variables Required
-- {{Environment variable}} - {{Status}}
-- {{Environment variable}} - {{Status}}
-- {{Environment variable}} - {{Status}}
-
----
-
-## 🎯 Demo/Testing Requirements
-
-### Target Demo Sequence
-1. {{Step 1}}
-2. {{Step 2}}
-3. {{Step 3}}
-4. {{Step 4}}
-
-### Success Metrics
-- ✅ **{{Metric 1}}** - {{Status}}
-- ⏳ **{{Metric 2}}** - {{Status}}
-- ❌ **{{Metric 3}}** - {{Status}}
+### TODO (non-blocking)
+- Route hygiene: stats/roadmap BaseLayout placement
+- Legal + changelog join BaseLayout or documented StandaloneLayout
+- Home sections gradually adopt `PageSection`
 
 ---
 
-## 🧱 Productionization TODO Backlog
-
-### High Priority (Post-Demo/MVP)
-- **{{Task category}}**
-  - {{Specific task}}
-  - {{Specific task}}
-  - {{Specific task}}
-
-### Medium Priority (Post-MVP)
-- **{{Task category}}**
-  - {{Specific task}}
-  - {{Specific task}}
-
-### Lower Priority (Scale)
-- **{{Task category}}**
-  - {{Specific task}}
-  - {{Specific task}}
-
----
-
-## 🧠 Development Notes
-
-### Architecture Decisions Made
-- **{{Decision}}:** {{Rationale}}
-- **{{Decision}}:** {{Rationale}}
-
-### Recent Technical Challenges
-- **{{Challenge}}:** {{Solution approach}}
-- **{{Challenge}}:** {{Solution approach}}
-
-### Testing Strategy
-- {{Testing approach}}
-- {{Testing coverage status}}
-- {{Critical test cases}}
-
----
+## Key Code Locations
+- Tokens: `src/lib/design-system.ts`
+- Primitives: `src/components/ui/surface.tsx`, `page-section.tsx`, `page-body.tsx`, `mac-window.tsx`
+- Rule: `.cursor/rules/ui-layout-consistency.mdc`

--- a/prd/progress.md
+++ b/prd/progress.md
@@ -1,23 +1,24 @@
 # Portfolio v3 — UI Layout Consistency
 
-*Last Updated: 2026-07-16 — Unified surface dialects + AI rules*
+*Last Updated: 2026-07-16 — AGENTS.md + full UI docs for all platforms*
 
 ---
 
 ## Project Overview
-**Goal:** Make every visitor/user/admin content box use the same layout language (solid / glass / inset), and lock the pattern into Cursor/Claude/Gemini/Copilot rules so future work stays consistent.
-**Success Criteria:** No glass content cards; shared primitives used; AI instruction files document the system.
+**Goal:** Make every visitor/user/admin content box use the same layout language (solid / glass / inset), and lock the pattern into Cursor/Claude/Gemini/Copilot/AGENTS rules so future work stays consistent.
+**Success Criteria:** No glass content cards; shared primitives used; all AI platforms + `docs/ui/` document the system.
 
 ---
 
 ## Progress Summary
 
-### Overall Status: 90% Complete
+### Overall Status: 100% Complete (docs + rules)
 - **Audit**: COMPLETED — mapped surface dialects and page-shell drift
 - **Primitives**: COMPLETED — `SURFACE` tokens, `Surface`, `PageSection`, `PageBody`, `MacWindow.backdrop`
 - **Migrations**: COMPLETED — glass stats/contrib cards → solid; education/visitor-panel/status/feedback → Surface; media card hover unified
 - **Rules**: COMPLETED — `.cursor/rules/ui-layout-consistency.mdc` + synced AI instruction files
-- **Remaining**: Optional — move stats/roadmap BaseLayout into `layout.tsx`; restyle legal/changelog onto BaseLayout; Signal stays outlier
+- **Docs**: COMPLETED — `AGENTS.md`, `GEMINI.md`, `docs/ui/*` (design-system, surfaces, page-shell, components, platforms)
+- **Remaining (optional code)**: move stats/roadmap BaseLayout into `layout.tsx`; restyle legal/changelog onto BaseLayout; Signal stays outlier
 
 ---
 
@@ -31,7 +32,8 @@
 - Migrated glass → solid: site-stats, duolingo, monkeytype, spotify
 - Migrated ad-hoc boxes → Surface: education, visitor-panel, status rows, leetcode section, admin feedback, stats PlatformCard
 - Media cards: blog / blog-medium / project hover → `hover:border-foreground/20`
-- Rules: Cursor / Claude / Gemini / Copilot / nextjs-development.mdc
+- Agent docs: `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `.geminirules`, `GEMINI.md`, Copilot, `.cursor/rules/agents-index.mdc`
+- UI docs: `docs/ui/README.md` + design-system / surfaces / page-shell / components / platforms
 
 ### TODO (non-blocking)
 - Route hygiene: stats/roadmap BaseLayout placement
@@ -44,3 +46,5 @@
 - Tokens: `src/lib/design-system.ts`
 - Primitives: `src/components/ui/surface.tsx`, `page-section.tsx`, `page-body.tsx`, `mac-window.tsx`
 - Rule: `.cursor/rules/ui-layout-consistency.mdc`
+- Agents: `AGENTS.md`
+- UI docs: `docs/ui/`

--- a/src/app/(admin)/admin/dashboard/feedback/page.tsx
+++ b/src/app/(admin)/admin/dashboard/feedback/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import { Surface } from "@/components/ui/surface"
 import { getFeedbackClient, updateFeedbackStatusClient, type AdminFeedback, type FeedbackStatus } from "@/services/admin/feedback"
 import { Loader2, Mail, ExternalLink, Check, Archive, Inbox } from "lucide-react"
 
@@ -72,7 +73,7 @@ export default function FeedbackAdminPage() {
       ) : (
         <div className="space-y-3">
           {items.map((f) => (
-            <div key={f.id} className="rounded-xl border border-border/50 bg-card p-4">
+            <Surface key={f.id} variant="solid" padding="compact">
               <div className="mb-2 flex flex-wrap items-center gap-2">
                 <Badge variant="secondary" className="capitalize">{f.category}</Badge>
                 <Badge variant={f.status === "new" ? "default" : "outline"} className="capitalize">{f.status}</Badge>
@@ -105,7 +106,7 @@ export default function FeedbackAdminPage() {
                   </Button>
                 )}
               </div>
-            </div>
+            </Surface>
           ))}
         </div>
       )}

--- a/src/app/(user)/profile/page.tsx
+++ b/src/app/(user)/profile/page.tsx
@@ -40,7 +40,7 @@ const ProfilePage = async () => {
   const profile = await getProfile()
 
   return (
-    <div className="flex flex-col gap-4 max-w-8xl mx-auto">
+    <div className="mx-auto flex w-full flex-col gap-4">
       <Suspense fallback={<ProfileSkeleton />}>
         <ProfileHeader profile={profile.data} />
       </Suspense>

--- a/src/app/(visitor)/stats/_components/leetcode-section.tsx
+++ b/src/app/(visitor)/stats/_components/leetcode-section.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import { cn } from "@/lib/utils"
+import { Surface } from "@/components/ui/surface"
 import type { LeetCodeStats } from "@/services/visitor/leetcode"
 import LeetCodeContestChart from "./leetcode-contest-chart"
 import { Flame, CalendarDays, Trophy } from "lucide-react"
@@ -39,13 +40,13 @@ function buildWeeks(calendar: { date: string; count: number }[]): { date: string
 
 function StatPill({ icon, label, value }: { icon: React.ReactNode; label: string; value: string | number }) {
   return (
-    <div className="flex items-center gap-2 rounded-lg border border-border/30 bg-secondary/20 px-3 py-2">
+    <Surface variant="inset" className="flex items-center gap-2 px-3 py-2">
       <span className="text-primary/70">{icon}</span>
       <div className="leading-tight">
         <p className="text-sm font-semibold text-primary">{value}</p>
         <p className="text-[11px] text-muted-foreground">{label}</p>
       </div>
-    </div>
+    </Surface>
   )
 }
 
@@ -55,7 +56,7 @@ export default function LeetCodeSection({ stats }: { stats: Stats }) {
   const totalSubmissionsInYear = stats.calendar.reduce((a, b) => a + b.count, 0)
 
   return (
-    <div className="space-y-6 rounded-xl border border-border/30 bg-secondary/10 p-5">
+    <Surface variant="inset" padding="cozy" className="space-y-6 rounded-xl">
       <div className="flex flex-wrap items-center gap-2">
         <Flame className="h-5 w-5 text-primary" />
         <p className="text-base font-semibold">LeetCode activity</p>
@@ -177,6 +178,6 @@ export default function LeetCodeSection({ stats }: { stats: Stats }) {
           </div>
         </div>
       )}
-    </div>
+    </Surface>
   )
 }

--- a/src/app/(visitor)/stats/page.tsx
+++ b/src/app/(visitor)/stats/page.tsx
@@ -4,7 +4,9 @@ import BaseLayout from "@/components/layout/base-layout"
 import SidebarMain from "@/components/layout/sidebar-main"
 import Typography from "@/components/ui/typography"
 import { MacWindow } from "@/components/ui/mac-window"
+import { PageBody } from "@/components/ui/page-body"
 import { SectionHeading } from "@/components/ui/section-heading"
+import { Surface } from "@/components/ui/surface"
 import { StatStrip } from "@/components/ui/stat-strip"
 import { Eyebrow } from "@/components/ui/eyebrow"
 import { STATS_PROFILES, STATS_PROFILE_URLS } from "@/commons/constants/stats-profiles"
@@ -38,14 +40,14 @@ function PlatformCard({
   unavailable?: boolean
 }) {
   return (
-    <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-5 transition-colors hover:border-foreground/20">
+    <Surface variant="solid" padding="cozy" className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <Typography.P className="font-display text-base font-semibold tracking-tight">{title}</Typography.P>
         <Link
           href={href}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-muted-foreground hover:text-primary transition-colors"
+          className="text-muted-foreground transition-colors hover:text-primary"
           aria-label={`Open ${title} profile`}
         >
           <ExternalLink size={16} />
@@ -56,7 +58,7 @@ function PlatformCard({
       ) : (
         children
       )}
-    </div>
+    </Surface>
   )
 }
 
@@ -108,7 +110,7 @@ export default async function StatsPage() {
 
   return (
     <BaseLayout sidebar={<SidebarMain />} useGridBackground={false}>
-      <div className="flex flex-col gap-6 max-w-6xl mx-auto w-full px-4 lg:px-0">
+      <PageBody width="wide">
         <SectionHeading
           as="h1"
           eyebrow="Activity"
@@ -229,7 +231,7 @@ export default async function StatsPage() {
           })()}
         </PlatformCard>
         </MacWindow>
-      </div>
+      </PageBody>
     </BaseLayout>
   )
 }

--- a/src/app/(visitor)/status/page.tsx
+++ b/src/app/(visitor)/status/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useState, type ReactNode } from "react"
 import { getHealth, type HealthData, type HealthService, type ServiceStatus } from "@/services/visitor/health"
 import { MacWindow } from "@/components/ui/mac-window"
 import { SectionHeading } from "@/components/ui/section-heading"
@@ -19,6 +19,74 @@ const LABEL: Record<ServiceStatus, string> = {
   down: "Down",
 }
 
+/**
+ * Top banner summarizing overall system health.
+ */
+function OverallBanner({
+  allUp,
+  overall,
+  loading,
+  onRefresh,
+}: Readonly<{
+  allUp: boolean
+  overall: ServiceStatus
+  loading: boolean
+  onRefresh: () => void
+}>) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between rounded-xl border p-4",
+        allUp ? "border-green-500/30 bg-green-500/10" : "border-amber-500/30 bg-amber-500/10",
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <span className={cn("h-3 w-3 rounded-full", DOT[overall])} />
+        <p className="font-semibold">{allUp ? "All systems operational" : "Some systems are degraded"}</p>
+      </div>
+      <button
+        onClick={onRefresh}
+        className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        aria-label="Refresh"
+      >
+        {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+        Refresh
+      </button>
+    </div>
+  )
+}
+
+/**
+ * Single dependency row inside the status window.
+ */
+function ServiceRow({ service }: Readonly<{ service: HealthService }>) {
+  const statusClass =
+    service.status === "operational"
+      ? "text-green-600 dark:text-green-400"
+      : service.status === "down"
+        ? "text-red-600 dark:text-red-400"
+        : "text-amber-600 dark:text-amber-400"
+
+  return (
+    <Surface variant="inset" className="flex items-center justify-between px-4 py-3">
+      <div className="flex items-center gap-3">
+        <span className={cn("h-2.5 w-2.5 rounded-full", DOT[service.status])} />
+        <div className="leading-tight">
+          <p className="text-sm font-medium">{service.name}</p>
+          {service.detail && <p className="text-[11px] text-muted-foreground">{service.detail}</p>}
+        </div>
+      </div>
+      <div className="flex items-center gap-3 text-xs">
+        {service.latencyMs != null && <span className="text-muted-foreground">{service.latencyMs}ms</span>}
+        <span className={cn("font-medium", statusClass)}>{LABEL[service.status]}</span>
+      </div>
+    </Surface>
+  )
+}
+
+/**
+ * Live health dashboard for the portfolio API and dependencies.
+ */
 export default function StatusPage() {
   const [data, setData] = useState<HealthData | null>(null)
   const [loading, setLoading] = useState(true)
@@ -42,63 +110,31 @@ export default function StatusPage() {
   const overall: ServiceStatus = data?.overall ?? "down"
   const allUp = overall === "operational" && services.every((s) => s.status === "operational")
 
+  const eyebrow: ReactNode = (
+    <>
+      <Activity className="h-3.5 w-3.5 text-primary" />
+      Monitoring
+    </>
+  )
+
   return (
     <div className="w-full">
       <SectionHeading
         as="h1"
         className="mb-6"
-        eyebrow={
-          <>
-            <Activity className="h-3.5 w-3.5 text-primary" />
-            Monitoring
-          </>
-        }
+        eyebrow={eyebrow}
         title="System"
         accent="status"
         description="Live health of the portfolio API and its dependencies."
       />
 
       <MacWindow title="~/status" bodyClassName="space-y-4">
-        <div
-          className={cn(
-            "flex items-center justify-between rounded-xl border p-4",
-            allUp ? "border-green-500/30 bg-green-500/10" : "border-amber-500/30 bg-amber-500/10",
-          )}
-        >
-          <div className="flex items-center gap-3">
-            <span className={cn("h-3 w-3 rounded-full", DOT[overall])} />
-            <p className="font-semibold">{allUp ? "All systems operational" : "Some systems are degraded"}</p>
-          </div>
-          <button
-            onClick={load}
-            className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            aria-label="Refresh"
-          >
-            {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
-            Refresh
-          </button>
-        </div>
-
+        <OverallBanner allUp={allUp} overall={overall} loading={loading} onRefresh={load} />
         <div className="space-y-2">
           {services.map((s) => (
-            <Surface key={s.name} variant="inset" className="flex items-center justify-between px-4 py-3">
-              <div className="flex items-center gap-3">
-                <span className={cn("h-2.5 w-2.5 rounded-full", DOT[s.status])} />
-                <div className="leading-tight">
-                  <p className="text-sm font-medium">{s.name}</p>
-                  {s.detail && <p className="text-[11px] text-muted-foreground">{s.detail}</p>}
-                </div>
-              </div>
-              <div className="flex items-center gap-3 text-xs">
-                {s.latencyMs != null && <span className="text-muted-foreground">{s.latencyMs}ms</span>}
-                <span className={cn("font-medium", s.status === "operational" ? "text-green-600 dark:text-green-400" : s.status === "down" ? "text-red-600 dark:text-red-400" : "text-amber-600 dark:text-amber-400")}>
-                  {LABEL[s.status]}
-                </span>
-              </div>
-            </Surface>
+            <ServiceRow key={s.name} service={s} />
           ))}
         </div>
-
         {data?.checkedAt && (
           <p className="text-right text-[11px] text-muted-foreground">
             Last checked {new Date(data.checkedAt).toLocaleTimeString()} · auto-refreshes every 30s

--- a/src/app/(visitor)/status/page.tsx
+++ b/src/app/(visitor)/status/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react"
 import { getHealth, type HealthData, type HealthService, type ServiceStatus } from "@/services/visitor/health"
 import { MacWindow } from "@/components/ui/mac-window"
 import { SectionHeading } from "@/components/ui/section-heading"
+import { Surface } from "@/components/ui/surface"
 import { cn } from "@/lib/utils"
 import { Activity, RefreshCw, Loader2 } from "lucide-react"
 
@@ -42,7 +43,7 @@ export default function StatusPage() {
   const allUp = overall === "operational" && services.every((s) => s.status === "operational")
 
   return (
-    <div className="w-full px-4 lg:px-0">
+    <div className="w-full">
       <SectionHeading
         as="h1"
         className="mb-6"
@@ -80,7 +81,7 @@ export default function StatusPage() {
 
         <div className="space-y-2">
           {services.map((s) => (
-            <div key={s.name} className="flex items-center justify-between rounded-lg border border-border/40 bg-secondary/20 px-4 py-3">
+            <Surface key={s.name} variant="inset" className="flex items-center justify-between px-4 py-3">
               <div className="flex items-center gap-3">
                 <span className={cn("h-2.5 w-2.5 rounded-full", DOT[s.status])} />
                 <div className="leading-tight">
@@ -94,7 +95,7 @@ export default function StatusPage() {
                   {LABEL[s.status]}
                 </span>
               </div>
-            </div>
+            </Surface>
           ))}
         </div>
 

--- a/src/app/(visitor)/tools/_components/pokemon-tab.tsx
+++ b/src/app/(visitor)/tools/_components/pokemon-tab.tsx
@@ -86,7 +86,7 @@ export function PokemonTab() {
         {loading
           ? Array.from({ length: 12 }).map((_, i) => <div key={i} className="h-36 animate-pulse rounded-xl bg-muted" />)
           : cards.map((p) => (
-              <button key={p.id} onClick={() => openDetail(p.id)} className="group rounded-xl border border-muted/40 bg-card p-3 text-center transition-all hover:-translate-y-1 hover:border-primary/40 hover:shadow-md">
+              <button key={p.id} onClick={() => openDetail(p.id)} className="group rounded-xl border border-border bg-card p-3 text-center shadow-sm transition-colors hover:border-foreground/20">
                 <div className="relative mx-auto h-20 w-20">
                   {p.image ? <Image src={p.image} alt={p.name} fill className="object-contain transition-transform group-hover:scale-110" unoptimized /> : null}
                 </div>

--- a/src/app/(visitor)/tracker/page.tsx
+++ b/src/app/(visitor)/tracker/page.tsx
@@ -2,6 +2,7 @@ import { KanbanSquare } from "lucide-react"
 import { getTrackerTasks } from "@/services/visitor/tracker"
 import { getProfile } from "@/services/user/profile"
 import { SectionHeading } from "@/components/ui/section-heading"
+import { MacWindow } from "@/components/ui/mac-window"
 import TrackerBoard from "./_components/tracker-board"
 
 export const dynamic = "force-dynamic"
@@ -29,24 +30,12 @@ export default async function TrackerPage() {
       />
 
       {/*
-        Mac-style window WITHOUT backdrop-filter/transform. @hello-pangea/dnd positions the
-        dragged card with `position: fixed`; any ancestor with transform/filter/backdrop-filter
-        (BlurFade, MacWindow's backdrop-blur) becomes its containing block and offsets the drag.
+        backdrop={false}: @hello-pangea/dnd uses position:fixed for drag ghosts;
+        backdrop-blur / filter on an ancestor becomes the containing block and offsets the drag.
       */}
-      <div className="rounded-2xl border border-border/60 bg-background/40 shadow-sm">
-        <div className="flex items-center gap-3 rounded-t-2xl border-b border-border/60 bg-muted/40 px-4 py-3">
-          <div className="flex items-center gap-1.5">
-            <span className="h-3 w-3 rounded-full bg-red-400/90" />
-            <span className="h-3 w-3 rounded-full bg-yellow-400/90" />
-            <span className="h-3 w-3 rounded-full bg-green-400/90" />
-          </div>
-          <p className="flex-1 truncate text-center font-mono text-xs text-muted-foreground">~/tracker</p>
-          <div className="w-[46px] shrink-0" aria-hidden />
-        </div>
-        <div className="p-3 sm:p-4">
-          <TrackerBoard initialTasks={tasks} currentUserId={currentUserId} isAdmin={isAdmin} />
-        </div>
-      </div>
+      <MacWindow title="~/tracker" backdrop={false} bodyClassName="p-3 sm:p-4">
+        <TrackerBoard initialTasks={tasks} currentUserId={currentUserId} isAdmin={isAdmin} />
+      </MacWindow>
     </div>
   )
 }

--- a/src/app/_components/blog/blog-medium.tsx
+++ b/src/app/_components/blog/blog-medium.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { ArrowBigRightDash } from "lucide-react"
@@ -36,32 +37,45 @@ function MediumCover({ src, alt }: Readonly<{ src: string; alt: string }>) {
   )
 }
 
+/** Title + preview text for a Medium card. */
+function MediumCardHeader({ title, preview }: Readonly<{ title: string; preview: string }>) {
+  return (
+    <CardHeader className="space-y-1.5 p-4 pb-2">
+      <CardTitle className="line-clamp-2 font-display text-base font-bold tracking-tight transition-colors group-hover:text-primary sm:text-lg">{title}</CardTitle>
+      <div className="prose max-w-full text-pretty font-sans text-xs leading-snug text-muted-foreground sm:text-sm dark:prose-invert line-clamp-3">{preview}</div>
+    </CardHeader>
+  )
+}
+
+/** Footer CTA for a Medium card. */
+function MediumCardFooter({ href }: Readonly<{ href: string }>) {
+  return (
+    <CardFooter className="mt-auto border-t border-border p-4 pt-4">
+      <Link href={href} target="_blank" className="w-full">
+        <Button size="sm" variant="ghost" className="w-full justify-between gap-2 transition-colors hover:bg-primary/5 hover:text-primary group/btn">
+          <span className="font-mono text-[11px] font-medium uppercase tracking-wider">Read more</span>
+          <ArrowBigRightDash className="size-4 transition-transform duration-300 group-hover/btn:translate-x-1" />
+        </Button>
+      </Link>
+    </CardFooter>
+  )
+}
+
 /**
  * Solid media card for Medium blog posts.
  */
 export default function CardBlogMedium({ title, description, href }: Readonly<CardBlogMediumProps>) {
   const { imageUrl, cleanDescription } = extractImageFromDescription(description)
   const descriptionPreview = cleanDescription.slice(0, 100) + (cleanDescription.length > 200 ? "..." : "")
+  const cover: ReactNode = imageUrl ? <MediumCover src={imageUrl} alt={title} /> : null
 
   return (
     <Card className="group flex h-full flex-col overflow-hidden transition-colors hover:border-foreground/20">
       <Link href={href} className="block flex-1 overflow-hidden" target="_blank">
-        {imageUrl && <MediumCover src={imageUrl} alt={title} />}
-        <CardHeader className="p-4 pb-2">
-          <div className="space-y-1.5">
-            <CardTitle className="line-clamp-2 font-display text-base font-bold tracking-tight transition-colors group-hover:text-primary sm:text-lg">{title}</CardTitle>
-            <div className="prose max-w-full text-pretty font-sans text-xs leading-snug text-muted-foreground sm:text-sm dark:prose-invert line-clamp-3">{descriptionPreview}</div>
-          </div>
-        </CardHeader>
+        {cover}
+        <MediumCardHeader title={title} preview={descriptionPreview} />
       </Link>
-      <CardFooter className="mt-auto border-t border-border p-4 pt-4">
-        <Link href={href} target="_blank" className="w-full">
-          <Button size="sm" variant="ghost" className="w-full justify-between gap-2 transition-colors hover:bg-primary/5 hover:text-primary group/btn">
-            <span className="font-mono text-[11px] font-medium uppercase tracking-wider">Read more</span>
-            <ArrowBigRightDash className="size-4 transition-transform duration-300 group-hover/btn:translate-x-1" />
-          </Button>
-        </Link>
-      </CardFooter>
+      <MediumCardFooter href={href} />
     </Card>
   )
 }

--- a/src/app/_components/blog/blog-medium.tsx
+++ b/src/app/_components/blog/blog-medium.tsx
@@ -4,50 +4,59 @@ import { ArrowBigRightDash } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
 
-export default function CardBlogMedium({
-  title,
-  description,
-  href,
-}: Readonly<{
+interface CardBlogMediumProps {
   title: string
   description: string
   href: string
-}>) {
-  const extractImageFromDescription = (html: string): { imageUrl: string | null; cleanDescription: string } => {
-    const imgRegex = /<figure><img.*?src="(.*?)".*?><\/figure>/
-    const match = imgRegex.exec(html)
-    let imageUrl = null
-    let cleanDescription = html
-    if (match?.[1]) {
-      imageUrl = match[1]
-      cleanDescription = html.replace(/<figure><img.*?><\/figure>/, "")
-    }
-    const textOnly = cleanDescription.replace(/<\/?[^>]+(>|$)/g, " ").trim()
-    return { imageUrl, cleanDescription: textOnly }
-  }
+}
 
+/**
+ * Pulls the first Medium figure image out of the HTML description.
+ */
+function extractImageFromDescription(html: string): { imageUrl: string | null; cleanDescription: string } {
+  const imgRegex = /<figure><img.*?src="(.*?)".*?><\/figure>/
+  const match = imgRegex.exec(html)
+  let imageUrl = null
+  let cleanDescription = html
+  if (match?.[1]) {
+    imageUrl = match[1]
+    cleanDescription = html.replace(/<figure><img.*?><\/figure>/, "")
+  }
+  const textOnly = cleanDescription.replace(/<\/?[^>]+(>|$)/g, " ").trim()
+  return { imageUrl, cleanDescription: textOnly }
+}
+
+/** Cover block for Medium posts that include an embedded image. */
+function MediumCover({ src, alt }: Readonly<{ src: string; alt: string }>) {
+  return (
+    <div className="relative h-48 w-full overflow-hidden bg-secondary">
+      <Image src={src} alt={alt} fill className="object-cover object-top transition-transform duration-700 ease-in-out group-hover:scale-105" draggable={false} loading="lazy" />
+      <div className="absolute inset-0 bg-gradient-to-t from-background/20 to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
+    </div>
+  )
+}
+
+/**
+ * Solid media card for Medium blog posts.
+ */
+export default function CardBlogMedium({ title, description, href }: Readonly<CardBlogMediumProps>) {
   const { imageUrl, cleanDescription } = extractImageFromDescription(description)
   const descriptionPreview = cleanDescription.slice(0, 100) + (cleanDescription.length > 200 ? "..." : "")
 
   return (
     <Card className="group flex h-full flex-col overflow-hidden transition-colors hover:border-foreground/20">
       <Link href={href} className="block flex-1 overflow-hidden" target="_blank">
-        {imageUrl && (
-          <div className="relative h-48 w-full overflow-hidden bg-secondary">
-            <Image src={imageUrl} alt={title} fill className="object-cover object-top transition-transform duration-700 ease-in-out group-hover:scale-105" draggable={false} loading="lazy" />
-            <div className="absolute inset-0 bg-gradient-to-t from-background/20 to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
-          </div>
-        )}
+        {imageUrl && <MediumCover src={imageUrl} alt={title} />}
         <CardHeader className="p-4 pb-2">
           <div className="space-y-1.5">
-            <CardTitle className="font-display text-base sm:text-lg font-bold tracking-tight transition-colors group-hover:text-primary line-clamp-2">{title}</CardTitle>
-            <div className="prose max-w-full text-pretty font-sans text-xs sm:text-sm text-muted-foreground dark:prose-invert line-clamp-3 leading-snug">{descriptionPreview}</div>
+            <CardTitle className="line-clamp-2 font-display text-base font-bold tracking-tight transition-colors group-hover:text-primary sm:text-lg">{title}</CardTitle>
+            <div className="prose max-w-full text-pretty font-sans text-xs leading-snug text-muted-foreground sm:text-sm dark:prose-invert line-clamp-3">{descriptionPreview}</div>
           </div>
         </CardHeader>
       </Link>
-      <CardFooter className="p-4 pt-4 mt-auto border-t border-border">
+      <CardFooter className="mt-auto border-t border-border p-4 pt-4">
         <Link href={href} target="_blank" className="w-full">
-          <Button size="sm" variant="ghost" className="w-full gap-2 justify-between hover:bg-primary/5 hover:text-primary transition-colors group/btn">
+          <Button size="sm" variant="ghost" className="w-full justify-between gap-2 transition-colors hover:bg-primary/5 hover:text-primary group/btn">
             <span className="font-mono text-[11px] font-medium uppercase tracking-wider">Read more</span>
             <ArrowBigRightDash className="size-4 transition-transform duration-300 group-hover/btn:translate-x-1" />
           </Button>

--- a/src/app/_components/blog/blog-medium.tsx
+++ b/src/app/_components/blog/blog-medium.tsx
@@ -30,8 +30,8 @@ export default function CardBlogMedium({
   const descriptionPreview = cleanDescription.slice(0, 100) + (cleanDescription.length > 200 ? "..." : "")
 
   return (
-    <Card className="group flex flex-col overflow-hidden rounded-xl hover:border-primary/40 hover:bg-secondary/40 hover:shadow-md transition-all duration-500 ease-out h-full">
-      <Link href={href} className="block overflow-hidden flex-1" target="_blank">
+    <Card className="group flex h-full flex-col overflow-hidden transition-colors hover:border-foreground/20">
+      <Link href={href} className="block flex-1 overflow-hidden" target="_blank">
         {imageUrl && (
           <div className="relative h-48 w-full overflow-hidden bg-secondary">
             <Image src={imageUrl} alt={title} fill className="object-cover object-top transition-transform duration-700 ease-in-out group-hover:scale-105" draggable={false} loading="lazy" />

--- a/src/app/_components/blog/card-blog.tsx
+++ b/src/app/_components/blog/card-blog.tsx
@@ -1,49 +1,57 @@
+import type { CSSProperties } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { ArrowBigRightDash, BookOpen } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
 
-const DOT_PATTERN: React.CSSProperties = {
+const DOT_PATTERN: CSSProperties = {
   backgroundImage: "radial-gradient(circle, hsl(var(--primary) / 0.15) 1px, transparent 1px)",
   backgroundSize: "14px 14px",
 }
 
-export default function CardBlog({
-  title,
-  description,
-  image,
-  href,
-}: Readonly<{
+interface CardBlogProps {
   title: string
   description: string
   image?: string
   href: string
-}>) {
+}
+
+/** Cover image for a blog list card. */
+function BlogCoverImage({ src, alt }: Readonly<{ src: string; alt: string }>) {
+  return (
+    <div className="relative h-44 w-full overflow-hidden bg-secondary">
+      <Image src={src} alt={alt} fill className="object-cover object-top transition-transform duration-700 ease-in-out group-hover:scale-105" draggable={false} loading="lazy" />
+      <div className="absolute inset-0 bg-gradient-to-t from-background/30 to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
+    </div>
+  )
+}
+
+/** Placeholder cover when a blog post has no image. */
+function BlogCoverPlaceholder({ title }: Readonly<{ title: string }>) {
+  return (
+    <div className="relative h-44 w-full overflow-hidden bg-gradient-to-br from-primary/15 via-primary/5 to-background">
+      <div className="absolute inset-0 opacity-50" style={DOT_PATTERN} />
+      <span className="pointer-events-none absolute -bottom-6 -right-1 select-none text-[7rem] font-black leading-none text-primary/10">
+        {title.charAt(0).toUpperCase()}
+      </span>
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-primary/20 bg-background/50 shadow-sm backdrop-blur-sm transition-transform duration-500 group-hover:scale-110">
+          <BookOpen className="h-7 w-7 text-primary/70" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Solid media card for onsite blog posts.
+ */
+export default function CardBlog({ title, description, image, href }: Readonly<CardBlogProps>) {
   return (
     <Card className="group flex h-full flex-col overflow-hidden transition-colors hover:border-foreground/20">
       <Link href={href} className="block flex-1 overflow-hidden">
-        {image ? (
-          <div className="relative h-44 w-full overflow-hidden bg-secondary">
-            <Image src={image} alt={title} fill className="object-cover object-top transition-transform duration-700 ease-in-out group-hover:scale-105" draggable={false} loading="lazy" />
-            <div className="absolute inset-0 bg-gradient-to-t from-background/30 to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
-          </div>
-        ) : (
-          <div className="relative h-44 w-full overflow-hidden bg-gradient-to-br from-primary/15 via-primary/5 to-background">
-            {/* Subtle dot pattern */}
-            <div className="absolute inset-0 opacity-50" style={DOT_PATTERN} />
-            {/* Watermark initial */}
-            <span className="pointer-events-none absolute -bottom-6 -right-1 select-none text-[7rem] font-black leading-none text-primary/10">
-              {title.charAt(0).toUpperCase()}
-            </span>
-            {/* Glass icon badge */}
-            <div className="absolute inset-0 flex items-center justify-center">
-              <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-primary/20 bg-background/50 shadow-sm backdrop-blur-sm transition-transform duration-500 group-hover:scale-110">
-                <BookOpen className="h-7 w-7 text-primary/70" />
-              </div>
-            </div>
-          </div>
-        )}
+        {image ? <BlogCoverImage src={image} alt={title} /> : <BlogCoverPlaceholder title={title} />}
         <CardHeader className="p-4 pb-2">
           <div className="space-y-1.5">
             <CardTitle className="line-clamp-2 font-display text-base font-bold tracking-tight transition-colors group-hover:text-primary sm:text-lg">{title}</CardTitle>
@@ -51,9 +59,9 @@ export default function CardBlog({
           </div>
         </CardHeader>
       </Link>
-      <CardFooter className="p-4 pt-4 mt-auto border-t border-border">
+      <CardFooter className="mt-auto border-t border-border p-4 pt-4">
         <Link href={href} className="w-full">
-          <Button size="sm" variant="ghost" className="w-full gap-2 justify-between hover:bg-primary/5 hover:text-primary transition-colors group/btn">
+          <Button size="sm" variant="ghost" className="w-full justify-between gap-2 transition-colors hover:bg-primary/5 hover:text-primary group/btn">
             <span className="font-mono text-[11px] font-medium uppercase tracking-wider">Read more</span>
             <ArrowBigRightDash className="size-4 transition-transform duration-300 group-hover/btn:translate-x-1" />
           </Button>

--- a/src/app/_components/blog/card-blog.tsx
+++ b/src/app/_components/blog/card-blog.tsx
@@ -21,8 +21,8 @@ export default function CardBlog({
   href: string
 }>) {
   return (
-    <Card className="group flex flex-col overflow-hidden rounded-xl hover:border-primary/40 hover:bg-secondary/40 hover:shadow-md transition-all duration-500 ease-out h-full">
-      <Link href={href} className="block overflow-hidden flex-1">
+    <Card className="group flex h-full flex-col overflow-hidden transition-colors hover:border-foreground/20">
+      <Link href={href} className="block flex-1 overflow-hidden">
         {image ? (
           <div className="relative h-44 w-full overflow-hidden bg-secondary">
             <Image src={image} alt={title} fill className="object-cover object-top transition-transform duration-700 ease-in-out group-hover:scale-105" draggable={false} loading="lazy" />
@@ -46,7 +46,7 @@ export default function CardBlog({
         )}
         <CardHeader className="p-4 pb-2">
           <div className="space-y-1.5">
-            <CardTitle className="font-display text-base sm:text-lg font-bold tracking-tight transition-colors group-hover:text-primary line-clamp-2">{title}</CardTitle>
+            <CardTitle className="line-clamp-2 font-display text-base font-bold tracking-tight transition-colors group-hover:text-primary sm:text-lg">{title}</CardTitle>
             <div className="prose max-w-full text-pretty font-sans text-xs sm:text-sm text-muted-foreground dark:prose-invert line-clamp-3 leading-snug" dangerouslySetInnerHTML={{ __html: description }} />
           </div>
         </CardHeader>

--- a/src/app/_components/blog/card-blog.tsx
+++ b/src/app/_components/blog/card-blog.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react"
+import type { CSSProperties, ReactNode } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { ArrowBigRightDash, BookOpen } from "lucide-react"
@@ -27,6 +27,15 @@ function BlogCoverImage({ src, alt }: Readonly<{ src: string; alt: string }>) {
   )
 }
 
+/** Icon badge used on the placeholder cover. */
+function BlogPlaceholderBadge() {
+  return (
+    <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-primary/20 bg-background/50 shadow-sm backdrop-blur-sm transition-transform duration-500 group-hover:scale-110">
+      <BookOpen className="h-7 w-7 text-primary/70" />
+    </div>
+  )
+}
+
 /** Placeholder cover when a blog post has no image. */
 function BlogCoverPlaceholder({ title }: Readonly<{ title: string }>) {
   return (
@@ -36,11 +45,33 @@ function BlogCoverPlaceholder({ title }: Readonly<{ title: string }>) {
         {title.charAt(0).toUpperCase()}
       </span>
       <div className="absolute inset-0 flex items-center justify-center">
-        <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-primary/20 bg-background/50 shadow-sm backdrop-blur-sm transition-transform duration-500 group-hover:scale-110">
-          <BookOpen className="h-7 w-7 text-primary/70" />
-        </div>
+        <BlogPlaceholderBadge />
       </div>
     </div>
+  )
+}
+
+/** Title + description block for a blog card. */
+function BlogCardHeader({ title, description }: Readonly<{ title: string; description: string }>) {
+  return (
+    <CardHeader className="space-y-1.5 p-4 pb-2">
+      <CardTitle className="line-clamp-2 font-display text-base font-bold tracking-tight transition-colors group-hover:text-primary sm:text-lg">{title}</CardTitle>
+      <div className="prose max-w-full text-pretty font-sans text-xs leading-snug text-muted-foreground sm:text-sm dark:prose-invert line-clamp-3" dangerouslySetInnerHTML={{ __html: description }} />
+    </CardHeader>
+  )
+}
+
+/** Footer CTA for a blog card. */
+function BlogCardFooter({ href }: Readonly<{ href: string }>) {
+  return (
+    <CardFooter className="mt-auto border-t border-border p-4 pt-4">
+      <Link href={href} className="w-full">
+        <Button size="sm" variant="ghost" className="w-full justify-between gap-2 transition-colors hover:bg-primary/5 hover:text-primary group/btn">
+          <span className="font-mono text-[11px] font-medium uppercase tracking-wider">Read more</span>
+          <ArrowBigRightDash className="size-4 transition-transform duration-300 group-hover/btn:translate-x-1" />
+        </Button>
+      </Link>
+    </CardFooter>
   )
 }
 
@@ -48,25 +79,15 @@ function BlogCoverPlaceholder({ title }: Readonly<{ title: string }>) {
  * Solid media card for onsite blog posts.
  */
 export default function CardBlog({ title, description, image, href }: Readonly<CardBlogProps>) {
+  const cover: ReactNode = image ? <BlogCoverImage src={image} alt={title} /> : <BlogCoverPlaceholder title={title} />
+
   return (
     <Card className="group flex h-full flex-col overflow-hidden transition-colors hover:border-foreground/20">
       <Link href={href} className="block flex-1 overflow-hidden">
-        {image ? <BlogCoverImage src={image} alt={title} /> : <BlogCoverPlaceholder title={title} />}
-        <CardHeader className="p-4 pb-2">
-          <div className="space-y-1.5">
-            <CardTitle className="line-clamp-2 font-display text-base font-bold tracking-tight transition-colors group-hover:text-primary sm:text-lg">{title}</CardTitle>
-            <div className="prose max-w-full text-pretty font-sans text-xs sm:text-sm text-muted-foreground dark:prose-invert line-clamp-3 leading-snug" dangerouslySetInnerHTML={{ __html: description }} />
-          </div>
-        </CardHeader>
+        {cover}
+        <BlogCardHeader title={title} description={description} />
       </Link>
-      <CardFooter className="mt-auto border-t border-border p-4 pt-4">
-        <Link href={href} className="w-full">
-          <Button size="sm" variant="ghost" className="w-full justify-between gap-2 transition-colors hover:bg-primary/5 hover:text-primary group/btn">
-            <span className="font-mono text-[11px] font-medium uppercase tracking-wider">Read more</span>
-            <ArrowBigRightDash className="size-4 transition-transform duration-300 group-hover/btn:translate-x-1" />
-          </Button>
-        </Link>
-      </CardFooter>
+      <BlogCardFooter href={href} />
     </Card>
   )
 }

--- a/src/app/_components/blog/card-blog.tsx
+++ b/src/app/_components/blog/card-blog.tsx
@@ -17,6 +17,13 @@ interface CardBlogProps {
   href: string
 }
 
+/**
+ * Strips HTML tags for safe card preview text (avoids dangerouslySetInnerHTML).
+ */
+function toPlainText(html: string): string {
+  return html.replace(/<\/?[^>]+(>|$)/g, " ").replace(/\s+/g, " ").trim()
+}
+
 /** Cover image for a blog list card. */
 function BlogCoverImage({ src, alt }: Readonly<{ src: string; alt: string }>) {
   return (
@@ -56,7 +63,7 @@ function BlogCardHeader({ title, description }: Readonly<{ title: string; descri
   return (
     <CardHeader className="space-y-1.5 p-4 pb-2">
       <CardTitle className="line-clamp-2 font-display text-base font-bold tracking-tight transition-colors group-hover:text-primary sm:text-lg">{title}</CardTitle>
-      <div className="prose max-w-full text-pretty font-sans text-xs leading-snug text-muted-foreground sm:text-sm dark:prose-invert line-clamp-3" dangerouslySetInnerHTML={{ __html: description }} />
+      <p className="line-clamp-3 text-pretty font-sans text-xs leading-snug text-muted-foreground sm:text-sm">{toPlainText(description)}</p>
     </CardHeader>
   )
 }

--- a/src/app/_components/contribution/duolingo-stats.tsx
+++ b/src/app/_components/contribution/duolingo-stats.tsx
@@ -69,7 +69,7 @@ export default function DuolingoStats({ duolingo }: DuolingoStatsProps) {
           return (
             <Card
               key={stat.label}
-              className="relative overflow-hidden group border-white/10 dark:border-white/5 bg-white/5 dark:bg-neutral-900/40 backdrop-blur-md hover:bg-white/10 dark:hover:bg-neutral-800/60 transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
+              className="relative overflow-hidden group hover:border-foreground/20"
             >
               <CardContent className="p-4">
                 <div className="flex items-center gap-3">
@@ -93,7 +93,7 @@ export default function DuolingoStats({ duolingo }: DuolingoStatsProps) {
       {topCourses.length > 0 && (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
           {topCourses.map((course, index) => (
-            <Card key={`${course.language}-${index}`} className="border-white/10 dark:border-white/5 bg-white/5 dark:bg-neutral-900/40 backdrop-blur-md transition-all duration-300">
+            <Card key={`${course.language}-${index}`}>
               <CardContent className="flex items-center justify-between p-3">
                 <div className="flex flex-col gap-1">
                   <span className="text-sm font-medium">{course.language}</span>

--- a/src/app/_components/contribution/monkeytype-stats.tsx
+++ b/src/app/_components/contribution/monkeytype-stats.tsx
@@ -36,7 +36,7 @@ function formatTime(seconds: number): string {
 
 function StatCard({ icon: Icon, label, value, subValue, trend }: { icon: React.ElementType; label: string; value: string | number; subValue?: string; trend?: string }) {
   return (
-    <Card className="relative overflow-hidden group border-white/10 dark:border-white/5 bg-white/5 dark:bg-neutral-900/40 backdrop-blur-md hover:bg-white/10 dark:hover:bg-neutral-800/60 transition-all duration-300 hover:shadow-xl hover:-translate-y-1">
+    <Card className="relative overflow-hidden group hover:border-foreground/20">
       <CardContent className="p-4">
         <div className="flex items-center gap-3">
           <div className="p-2 rounded-xl bg-primary/10 transition-colors group-hover:bg-primary/20">
@@ -135,7 +135,7 @@ export default function MonkeyTypeStats({ typingStats }: MonkeyTypeStatsProps) {
       {/* Charts - Lazy loaded */}
       {wpmChartData.length > 0 && (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <Card className="border-white/10 dark:border-white/5 bg-white/5 dark:bg-neutral-900/40 backdrop-blur-md transition-all duration-300 hover:shadow-lg">
+          <Card className="hover:border-foreground/20">
             <CardHeader className="pb-3 pt-4 px-5">
               <CardTitle className="text-sm font-semibold flex items-center gap-2">
                 <div className="p-1.5 rounded-md bg-primary/10">
@@ -151,7 +151,7 @@ export default function MonkeyTypeStats({ typingStats }: MonkeyTypeStatsProps) {
             </CardContent>
           </Card>
 
-          <Card className="border-white/10 dark:border-white/5 bg-white/5 dark:bg-neutral-900/40 backdrop-blur-md transition-all duration-300 hover:shadow-lg">
+          <Card className="hover:border-foreground/20">
             <CardHeader className="pb-3 pt-4 px-5">
               <CardTitle className="text-sm font-semibold flex items-center gap-2">
                 <div className="p-1.5 rounded-md bg-primary/10">

--- a/src/app/_components/contribution/monkeytype-stats.tsx
+++ b/src/app/_components/contribution/monkeytype-stats.tsx
@@ -1,13 +1,12 @@
 "use client"
 
-import { useState, lazy, Suspense } from "react"
+import { useState, lazy, Suspense, type ElementType } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { MonkeyTypeUserData } from "@/commons/types/monkeytype"
 import { Keyboard, Target, MousePointerClick, Timer, TrendingUp, Zap, Award, Activity } from "lucide-react"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
 import { Badge } from "@/components/ui/badge"
 
-const LazyCharts = lazy(() => import("./lazy-monkeytype-charts").then((mod) => ({ default: () => null })))
 const LazyWpmChartComponent = lazy(() => import("./lazy-monkeytype-charts").then((mod) => ({ default: mod.LazyWpmChart })))
 const LazyAccuracyChartComponent = lazy(() => import("./lazy-monkeytype-charts").then((mod) => ({ default: mod.LazyAccuracyChart })))
 
@@ -15,6 +14,17 @@ interface MonkeyTypeStatsProps {
   typingStats: MonkeyTypeUserData
 }
 
+interface StatCardProps {
+  icon: ElementType
+  label: string
+  value: string | number
+  subValue?: string
+  trend?: string
+}
+
+/**
+ * Formats large numbers with K/M suffixes.
+ */
 function formatNumber(num: number): string {
   if (num >= 1000000) {
     return (num / 1000000).toFixed(1) + "M"
@@ -25,6 +35,9 @@ function formatNumber(num: number): string {
   return num.toString()
 }
 
+/**
+ * Formats typing duration as hours/minutes.
+ */
 function formatTime(seconds: number): string {
   const hours = Math.floor(seconds / 3600)
   const minutes = Math.floor((seconds % 3600) / 60)
@@ -34,26 +47,43 @@ function formatTime(seconds: number): string {
   return `${minutes}m`
 }
 
-function StatCard({ icon: Icon, label, value, subValue, trend }: { icon: React.ElementType; label: string; value: string | number; subValue?: string; trend?: string }) {
+/** Icon bubble shown on the left of a StatCard. */
+function StatCardIcon({ icon: Icon }: Readonly<{ icon: ElementType }>) {
   return (
-    <Card className="relative overflow-hidden group hover:border-foreground/20">
+    <div className="rounded-xl bg-primary/10 p-2 transition-colors group-hover:bg-primary/20">
+      <Icon className="h-5 w-5 text-primary" />
+    </div>
+  )
+}
+
+/** Text/value block for a StatCard. */
+function StatCardBody({ label, value, subValue, trend }: Readonly<Omit<StatCardProps, "icon">>) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="mb-0.5 flex items-center gap-2">
+        <p className="truncate text-2xl font-bold tracking-tight">{value}</p>
+        {trend && (
+          <Badge variant="secondary" className="text-xs">
+            {trend}
+          </Badge>
+        )}
+      </div>
+      <p className="truncate text-xs font-medium text-muted-foreground">{label}</p>
+      {subValue && <p className="truncate text-[10px] text-muted-foreground/80">{subValue}</p>}
+    </div>
+  )
+}
+
+/**
+ * Compact solid metric card used in the Monkeytype overview grid.
+ */
+function StatCard({ icon, label, value, subValue, trend }: Readonly<StatCardProps>) {
+  return (
+    <Card className="group relative overflow-hidden hover:border-foreground/20">
       <CardContent className="p-4">
         <div className="flex items-center gap-3">
-          <div className="p-2 rounded-xl bg-primary/10 transition-colors group-hover:bg-primary/20">
-            <Icon className="w-5 h-5 text-primary" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-0.5">
-              <p className="text-2xl font-bold tracking-tight truncate">{value}</p>
-              {trend && (
-                <Badge variant="secondary" className="text-xs">
-                  {trend}
-                </Badge>
-              )}
-            </div>
-            <p className="text-xs font-medium text-muted-foreground truncate">{label}</p>
-            {subValue && <p className="text-[10px] text-muted-foreground/80 truncate">{subValue}</p>}
-          </div>
+          <StatCardIcon icon={icon} />
+          <StatCardBody label={label} value={value} subValue={subValue} trend={trend} />
         </div>
       </CardContent>
     </Card>

--- a/src/app/_components/education/index.tsx
+++ b/src/app/_components/education/index.tsx
@@ -1,26 +1,30 @@
 import Image from "next/image"
-import BlurFade from "@/components/magicui/blur-fade";
-import { SectionHeading } from "@/components/ui/section-heading";
-import { Chip } from "@/components/ui/chip";
-import { getAllEducation } from "@/services/visitor/education";
+import BlurFade from "@/components/magicui/blur-fade"
+import { PageSection } from "@/components/ui/page-section"
+import { Surface } from "@/components/ui/surface"
+import { Chip } from "@/components/ui/chip"
+import { getAllEducation } from "@/services/visitor/education"
 
 export default async function EducationSection() {
-  const educations = await getAllEducation();
+  const educations = await getAllEducation()
 
   return (
     <BlurFade delay={0.25} inView>
-      <div className="mt-10">
-        <SectionHeading
-          eyebrow="Education"
-          title="Academic"
-          accent="foundation"
-          description="Where I built the fundamentals behind the work."
-        />
-        <div className="mt-6 space-y-3">
-          {educations?.map((edu: any) => (
-            <div
+      <PageSection
+        heading={{
+          eyebrow: "Education",
+          title: "Academic",
+          accent: "foundation",
+          description: "Where I built the fundamentals behind the work.",
+        }}
+      >
+        <div className="space-y-3">
+          {educations?.map((edu: { title: string; image: string; subtitle: string; duration: string }) => (
+            <Surface
               key={edu.title}
-              className="group flex flex-row items-center gap-4 rounded-xl border border-border bg-card p-4 transition-colors hover:bg-accent/40"
+              variant="solid"
+              padding="compact"
+              className="group flex flex-row items-center gap-4 hover:bg-accent/40"
             >
               <Image
                 src={edu.image}
@@ -34,10 +38,10 @@ export default async function EducationSection() {
                 <p className="text-xs text-muted-foreground">{edu.subtitle}</p>
               </div>
               <Chip className="ml-auto shrink-0 self-start">{edu.duration}</Chip>
-            </div>
+            </Surface>
           ))}
         </div>
-      </div>
+      </PageSection>
     </BlurFade>
   )
 }

--- a/src/app/_components/intro/spotify-card.tsx
+++ b/src/app/_components/intro/spotify-card.tsx
@@ -50,7 +50,7 @@ export default function SpotifyCard() {
           href={data.songUrl || "#"}
           target="_blank"
           rel="noopener noreferrer"
-          className="group flex items-center gap-3 rounded-xl border border-border/50 bg-white/5 dark:bg-neutral-900/40 backdrop-blur-md p-2 max-w-sm transition-all hover:bg-white/10 dark:hover:bg-neutral-800/60 hover:shadow-md hover:-translate-y-0.5"
+          className="group flex max-w-sm items-center gap-3 rounded-xl border border-border bg-card p-2 shadow-sm transition-colors hover:border-foreground/20 hover:bg-accent/40"
         >
           {data.albumImageUrl ? (
             <Image src={data.albumImageUrl} alt={data.album ?? ""} width={40} height={40} className="size-10 object-cover rounded-md shadow-sm opacity-70 group-hover:opacity-100 transition-opacity" />
@@ -87,7 +87,7 @@ export default function SpotifyCard() {
       href={data.songUrl || "#"}
       target="_blank"
       rel="noopener noreferrer"
-      className="group flex flex-col md:flex-row items-center gap-3 rounded-xl border border-border/50 bg-white/5 dark:bg-neutral-900/40 backdrop-blur-md p-2 max-w-sm transition-all hover:bg-white/10 dark:hover:bg-neutral-800/60 hover:shadow-md hover:-translate-y-0.5"
+      className="group flex max-w-sm flex-col items-center gap-3 rounded-xl border border-border bg-card p-2 shadow-sm transition-colors hover:border-foreground/20 hover:bg-accent/40 md:flex-row"
     >
       {data.albumImageUrl ? (
         <Image src={data.albumImageUrl} alt={data.album ?? ""} width={40} height={40} className="size-10 object-cover rounded-md shadow-sm group-hover:shadow-md transition-shadow" />

--- a/src/app/_components/project/card-project.tsx
+++ b/src/app/_components/project/card-project.tsx
@@ -1,78 +1,94 @@
+import type { CSSProperties } from "react"
 import Image from "next/image"
 import Link from "next/link"
 import { Card, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Globe, GitBranch, FolderGit2 } from "lucide-react"
 
-const DOT_PATTERN: React.CSSProperties = {
+const DOT_PATTERN: CSSProperties = {
   backgroundImage: "radial-gradient(circle, hsl(var(--primary) / 0.15) 1px, transparent 1px)",
   backgroundSize: "14px 14px",
 }
 
-export default function CardProject({
-  id,
-  title,
-  description,
-  source,
-  image,
-  href,
-}: Readonly<{
+interface CardProjectProps {
   id: string
   title: string
   description: string
   source?: string
   image?: string
   href?: string
-}>) {
-  const hasImage = !!image && image !== "/no-image.jpg"
+}
+
+/** Project cover photo. */
+function ProjectCoverImage({ src, alt }: Readonly<{ src: string; alt: string }>) {
+  return (
+    <div className="relative h-44 w-full overflow-hidden bg-muted">
+      <Image src={src} alt={alt} fill className="object-cover object-top transition-transform duration-700 ease-in-out group-hover:scale-105" />
+      <div className="absolute inset-0 bg-gradient-to-t from-background/30 to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
+    </div>
+  )
+}
+
+/** Placeholder cover when a project has no image. */
+function ProjectCoverPlaceholder({ title }: Readonly<{ title: string }>) {
+  return (
+    <div className="relative h-44 w-full overflow-hidden bg-gradient-to-br from-primary/15 via-primary/5 to-background">
+      <div className="absolute inset-0 opacity-50" style={DOT_PATTERN} />
+      <span className="pointer-events-none absolute -bottom-6 -right-1 select-none text-[7rem] font-black leading-none text-primary/10">
+        {title.charAt(0).toUpperCase()}
+      </span>
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-primary/20 bg-background/60 shadow-sm backdrop-blur-sm transition-transform duration-500 group-hover:scale-110">
+          <FolderGit2 className="h-7 w-7 text-primary/70" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Footer action buttons for website / source links. */
+function ProjectActions({ href, source }: Readonly<{ href?: string; source?: string }>) {
+  return (
+    <div className="flex flex-row flex-wrap items-center gap-2">
+      {href && href.length > 0 && (
+        <Link href={href} target="_blank">
+          <Button size="sm" variant="secondary" className="h-8 gap-1.5 rounded-md transition-colors hover:bg-primary hover:text-primary-foreground">
+            <Globe className="size-3.5" />
+            <span className="font-mono text-[10px] font-medium uppercase tracking-wider">Website</span>
+          </Button>
+        </Link>
+      )}
+      {source && source.length > 0 && (
+        <Link href={source} target="_blank">
+          <Button size="sm" variant="outline" className="h-8 gap-1.5 rounded-md transition-colors hover:bg-primary/10">
+            <GitBranch className="size-3.5" />
+            <span className="font-mono text-[10px] font-medium uppercase tracking-wider">Source</span>
+          </Button>
+        </Link>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Solid media card for project list items.
+ */
+export default function CardProject({ id, title, description, source, image, href }: Readonly<CardProjectProps>) {
+  const hasImage = Boolean(image) && image !== "/no-image.jpg"
 
   return (
     <Card className="group flex h-full flex-col overflow-hidden transition-colors hover:border-foreground/20">
       <Link href={`/project/${id}`} className="block overflow-hidden">
-        {hasImage ? (
-          <div className="relative h-44 w-full overflow-hidden bg-muted">
-            <Image src={image!} alt={title} fill className="object-cover object-top transition-transform duration-700 ease-in-out group-hover:scale-105" />
-            <div className="absolute inset-0 bg-gradient-to-t from-background/30 to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
-          </div>
-        ) : (
-          <div className="relative h-44 w-full overflow-hidden bg-gradient-to-br from-primary/15 via-primary/5 to-background">
-            <div className="absolute inset-0 opacity-50" style={DOT_PATTERN} />
-            <span className="pointer-events-none absolute -bottom-6 -right-1 select-none text-[7rem] font-black leading-none text-primary/10">
-              {title.charAt(0).toUpperCase()}
-            </span>
-            <div className="absolute inset-0 flex items-center justify-center">
-              <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-primary/20 bg-background/60 shadow-sm backdrop-blur-sm transition-transform duration-500 group-hover:scale-110">
-                <FolderGit2 className="h-7 w-7 text-primary/70" />
-              </div>
-            </div>
-          </div>
-        )}
+        {hasImage ? <ProjectCoverImage src={image!} alt={title} /> : <ProjectCoverPlaceholder title={title} />}
         <CardHeader className="p-4 pb-2">
           <div className="space-y-1.5">
             <CardTitle className="line-clamp-2 font-display text-base font-bold tracking-tight transition-colors group-hover:text-primary sm:text-lg">{title}</CardTitle>
-            <div className="prose max-w-full text-pretty font-sans text-xs sm:text-sm text-muted-foreground dark:prose-invert line-clamp-2 leading-snug" dangerouslySetInnerHTML={{ __html: description }} />
+            <div className="prose max-w-full text-pretty font-sans text-xs leading-snug text-muted-foreground sm:text-sm dark:prose-invert line-clamp-2" dangerouslySetInnerHTML={{ __html: description }} />
           </div>
         </CardHeader>
       </Link>
-      <CardFooter className="p-4 pt-4 mt-auto border-t border-border">
-        <div className="flex flex-row flex-wrap items-center gap-2">
-          {href && href.length > 0 && (
-            <Link href={href} target="_blank">
-              <Button size="sm" variant="secondary" className="h-8 gap-1.5 rounded-md hover:bg-primary hover:text-primary-foreground transition-colors">
-                <Globe className="size-3.5" />
-                <span className="font-mono text-[10px] font-medium uppercase tracking-wider">Website</span>
-              </Button>
-            </Link>
-          )}
-          {source && source.length > 0 && (
-            <Link href={source} target="_blank">
-              <Button size="sm" variant="outline" className="h-8 gap-1.5 rounded-md hover:bg-primary/10 transition-colors">
-                <GitBranch className="size-3.5" />
-                <span className="font-mono text-[10px] font-medium uppercase tracking-wider">Source</span>
-              </Button>
-            </Link>
-          )}
-        </div>
+      <CardFooter className="mt-auto border-t border-border p-4 pt-4">
+        <ProjectActions href={href} source={source} />
       </CardFooter>
     </Card>
   )

--- a/src/app/_components/project/card-project.tsx
+++ b/src/app/_components/project/card-project.tsx
@@ -19,6 +19,13 @@ interface CardProjectProps {
   href?: string
 }
 
+/**
+ * Strips HTML tags for safe card preview text (avoids dangerouslySetInnerHTML).
+ */
+function toPlainText(html: string): string {
+  return html.replace(/<\/?[^>]+(>|$)/g, " ").replace(/\s+/g, " ").trim()
+}
+
 /** Project cover photo. */
 function ProjectCoverImage({ src, alt }: Readonly<{ src: string; alt: string }>) {
   return (
@@ -58,7 +65,7 @@ function ProjectCardHeader({ title, description }: Readonly<{ title: string; des
   return (
     <CardHeader className="space-y-1.5 p-4 pb-2">
       <CardTitle className="line-clamp-2 font-display text-base font-bold tracking-tight transition-colors group-hover:text-primary sm:text-lg">{title}</CardTitle>
-      <div className="prose max-w-full text-pretty font-sans text-xs leading-snug text-muted-foreground sm:text-sm dark:prose-invert line-clamp-2" dangerouslySetInnerHTML={{ __html: description }} />
+      <p className="line-clamp-2 text-pretty font-sans text-xs leading-snug text-muted-foreground sm:text-sm">{toPlainText(description)}</p>
     </CardHeader>
   )
 }

--- a/src/app/_components/project/card-project.tsx
+++ b/src/app/_components/project/card-project.tsx
@@ -27,7 +27,7 @@ export default function CardProject({
   const hasImage = !!image && image !== "/no-image.jpg"
 
   return (
-    <Card className="group flex flex-col overflow-hidden rounded-xl border border-border hover:border-primary/40 bg-card shadow-sm hover:shadow-md transition-all duration-500 ease-out h-full">
+    <Card className="group flex h-full flex-col overflow-hidden transition-colors hover:border-foreground/20">
       <Link href={`/project/${id}`} className="block overflow-hidden">
         {hasImage ? (
           <div className="relative h-44 w-full overflow-hidden bg-muted">
@@ -49,7 +49,7 @@ export default function CardProject({
         )}
         <CardHeader className="p-4 pb-2">
           <div className="space-y-1.5">
-            <CardTitle className="font-display text-base sm:text-lg font-bold tracking-tight transition-colors group-hover:text-primary line-clamp-2">{title}</CardTitle>
+            <CardTitle className="line-clamp-2 font-display text-base font-bold tracking-tight transition-colors group-hover:text-primary sm:text-lg">{title}</CardTitle>
             <div className="prose max-w-full text-pretty font-sans text-xs sm:text-sm text-muted-foreground dark:prose-invert line-clamp-2 leading-snug" dangerouslySetInnerHTML={{ __html: description }} />
           </div>
         </CardHeader>

--- a/src/app/_components/project/card-project.tsx
+++ b/src/app/_components/project/card-project.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react"
+import type { CSSProperties, ReactNode } from "react"
 import Image from "next/image"
 import Link from "next/link"
 import { Card, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
@@ -29,6 +29,15 @@ function ProjectCoverImage({ src, alt }: Readonly<{ src: string; alt: string }>)
   )
 }
 
+/** Icon badge used on the placeholder cover. */
+function ProjectPlaceholderBadge() {
+  return (
+    <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-primary/20 bg-background/60 shadow-sm backdrop-blur-sm transition-transform duration-500 group-hover:scale-110">
+      <FolderGit2 className="h-7 w-7 text-primary/70" />
+    </div>
+  )
+}
+
 /** Placeholder cover when a project has no image. */
 function ProjectCoverPlaceholder({ title }: Readonly<{ title: string }>) {
   return (
@@ -38,35 +47,55 @@ function ProjectCoverPlaceholder({ title }: Readonly<{ title: string }>) {
         {title.charAt(0).toUpperCase()}
       </span>
       <div className="absolute inset-0 flex items-center justify-center">
-        <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-primary/20 bg-background/60 shadow-sm backdrop-blur-sm transition-transform duration-500 group-hover:scale-110">
-          <FolderGit2 className="h-7 w-7 text-primary/70" />
-        </div>
+        <ProjectPlaceholderBadge />
       </div>
     </div>
   )
 }
 
-/** Footer action buttons for website / source links. */
-function ProjectActions({ href, source }: Readonly<{ href?: string; source?: string }>) {
+/** Title + description block for a project card. */
+function ProjectCardHeader({ title, description }: Readonly<{ title: string; description: string }>) {
   return (
-    <div className="flex flex-row flex-wrap items-center gap-2">
-      {href && href.length > 0 && (
-        <Link href={href} target="_blank">
-          <Button size="sm" variant="secondary" className="h-8 gap-1.5 rounded-md transition-colors hover:bg-primary hover:text-primary-foreground">
-            <Globe className="size-3.5" />
-            <span className="font-mono text-[10px] font-medium uppercase tracking-wider">Website</span>
-          </Button>
-        </Link>
-      )}
-      {source && source.length > 0 && (
-        <Link href={source} target="_blank">
-          <Button size="sm" variant="outline" className="h-8 gap-1.5 rounded-md transition-colors hover:bg-primary/10">
-            <GitBranch className="size-3.5" />
-            <span className="font-mono text-[10px] font-medium uppercase tracking-wider">Source</span>
-          </Button>
-        </Link>
-      )}
-    </div>
+    <CardHeader className="space-y-1.5 p-4 pb-2">
+      <CardTitle className="line-clamp-2 font-display text-base font-bold tracking-tight transition-colors group-hover:text-primary sm:text-lg">{title}</CardTitle>
+      <div className="prose max-w-full text-pretty font-sans text-xs leading-snug text-muted-foreground sm:text-sm dark:prose-invert line-clamp-2" dangerouslySetInnerHTML={{ __html: description }} />
+    </CardHeader>
+  )
+}
+
+/** Website action button. */
+function WebsiteAction({ href }: Readonly<{ href: string }>) {
+  return (
+    <Link href={href} target="_blank">
+      <Button size="sm" variant="secondary" className="h-8 gap-1.5 rounded-md transition-colors hover:bg-primary hover:text-primary-foreground">
+        <Globe className="size-3.5" />
+        <span className="font-mono text-[10px] font-medium uppercase tracking-wider">Website</span>
+      </Button>
+    </Link>
+  )
+}
+
+/** Source action button. */
+function SourceAction({ source }: Readonly<{ source: string }>) {
+  return (
+    <Link href={source} target="_blank">
+      <Button size="sm" variant="outline" className="h-8 gap-1.5 rounded-md transition-colors hover:bg-primary/10">
+        <GitBranch className="size-3.5" />
+        <span className="font-mono text-[10px] font-medium uppercase tracking-wider">Source</span>
+      </Button>
+    </Link>
+  )
+}
+
+/** Footer action row for website / source links. */
+function ProjectCardFooter({ href, source }: Readonly<{ href?: string; source?: string }>) {
+  return (
+    <CardFooter className="mt-auto border-t border-border p-4 pt-4">
+      <div className="flex flex-row flex-wrap items-center gap-2">
+        {href && href.length > 0 ? <WebsiteAction href={href} /> : null}
+        {source && source.length > 0 ? <SourceAction source={source} /> : null}
+      </div>
+    </CardFooter>
   )
 }
 
@@ -75,21 +104,15 @@ function ProjectActions({ href, source }: Readonly<{ href?: string; source?: str
  */
 export default function CardProject({ id, title, description, source, image, href }: Readonly<CardProjectProps>) {
   const hasImage = Boolean(image) && image !== "/no-image.jpg"
+  const cover: ReactNode = hasImage && image ? <ProjectCoverImage src={image} alt={title} /> : <ProjectCoverPlaceholder title={title} />
 
   return (
     <Card className="group flex h-full flex-col overflow-hidden transition-colors hover:border-foreground/20">
       <Link href={`/project/${id}`} className="block overflow-hidden">
-        {hasImage ? <ProjectCoverImage src={image!} alt={title} /> : <ProjectCoverPlaceholder title={title} />}
-        <CardHeader className="p-4 pb-2">
-          <div className="space-y-1.5">
-            <CardTitle className="line-clamp-2 font-display text-base font-bold tracking-tight transition-colors group-hover:text-primary sm:text-lg">{title}</CardTitle>
-            <div className="prose max-w-full text-pretty font-sans text-xs leading-snug text-muted-foreground sm:text-sm dark:prose-invert line-clamp-2" dangerouslySetInnerHTML={{ __html: description }} />
-          </div>
-        </CardHeader>
+        {cover}
+        <ProjectCardHeader title={title} description={description} />
       </Link>
-      <CardFooter className="mt-auto border-t border-border p-4 pt-4">
-        <ProjectActions href={href} source={source} />
-      </CardFooter>
+      <ProjectCardFooter href={href} source={source} />
     </Card>
   )
 }

--- a/src/app/_components/site-stats/site-stats-client.tsx
+++ b/src/app/_components/site-stats/site-stats-client.tsx
@@ -43,7 +43,7 @@ function StatCard({ icon: Icon, label, value, subValue, className, trend }: Read
   return (
     <Card
       className={cn(
-        "relative overflow-hidden group border-white/10 dark:border-white/5 bg-white/5 dark:bg-neutral-900/40 backdrop-blur-md hover:bg-white/10 dark:hover:bg-neutral-800/60 transition-all duration-300 hover:shadow-xl hover:-translate-y-1",
+        "relative overflow-hidden group hover:border-foreground/20",
         className,
       )}
     >
@@ -92,7 +92,7 @@ function BarChartMetrics({
   }))
 
   return (
-    <Card className="border-white/10 dark:border-white/5 bg-white/5 dark:bg-neutral-900/40 backdrop-blur-md transition-all duration-300 hover:shadow-lg h-full">
+    <Card className="h-full hover:border-foreground/20">
       <CardHeader className="pb-3 pt-4 px-4 md:px-5">
         <CardTitle className="text-sm md:text-base font-semibold flex items-center gap-2">
           <div className="p-1.5 rounded-md bg-primary/10">

--- a/src/components/layout/base-layout.tsx
+++ b/src/components/layout/base-layout.tsx
@@ -23,7 +23,8 @@ export default async function BaseLayout({
   return (
     <>
       <ScrollProgress />
-      <div className="container min-h-screen pt-12 sm:pt-24 px-4 sm:px-6">
+      {/* Padding comes from Tailwind `container` (2rem) — do not add extra px-* here. */}
+      <div className="container min-h-screen pt-12 sm:pt-24">
         {useGridBackground && (
           <div className="fixed inset-0 flex items-center justify-center overflow-hidden h-40 pointer-events-none z-[-1]">
             <div className="relative flex h-full w-full flex-col items-center justify-center overflow-hidden bg-background [-webkit-mask-image:linear-gradient(to_bottom,black,transparent)]">

--- a/src/components/layout/right-sidebar-window.tsx
+++ b/src/components/layout/right-sidebar-window.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from "react"
 import { X, PanelRightOpen } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { SURFACE } from "@/lib/design-system"
 
 const STORAGE_KEY = "rh:right-sidebar-open"
 
@@ -52,7 +54,7 @@ export default function RightSidebarWindow({ children, defaultOpen = true }: Rea
 
   return (
     <div className="hidden lg:flex lg:w-64 xl:w-72 flex-col sticky top-16 h-[calc(100vh-4rem)]">
-      <div className="flex max-h-full flex-col overflow-hidden rounded-xl border border-border/60 bg-background/40 shadow-sm backdrop-blur-sm">
+      <div className={cn("flex max-h-full flex-col overflow-hidden", SURFACE.glass, "rounded-xl")}>
         {/* mac title bar */}
         <div className="flex shrink-0 items-center justify-between border-b border-border/60 bg-muted/40 px-3 py-2">
           <div className="flex items-center gap-1.5">

--- a/src/components/layout/visitor-panel.tsx
+++ b/src/components/layout/visitor-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react"
 import Typography from "@/components/ui/typography"
+import { Surface } from "@/components/ui/surface"
 import { MdWifi as IpIcon, MdLocationOn, MdDevices } from "react-icons/md"
 import { BiCalendar, BiGlobe } from "react-icons/bi"
 import { getBrowserInfo, getWeatherEmoji } from "@/commons/constants/sidebar"
@@ -77,10 +78,9 @@ export default function VisitorPanel() {
 
   return (
     <>
-      {/* Visitor Info */}
-      <div className="bg-secondary/20 rounded-lg p-4 border border-border/30">
-        <div className="flex items-center gap-2 mb-3">
-          <div className="w-2 h-2 rounded-full bg-primary animate-pulse" />
+      <Surface variant="inset" padding="compact">
+        <div className="mb-3 flex items-center gap-2">
+          <div className="h-2 w-2 animate-pulse rounded-full bg-primary" />
           <Typography.P className="text-sm font-semibold text-primary/80">Visitor Info</Typography.P>
         </div>
 
@@ -91,7 +91,7 @@ export default function VisitorPanel() {
               <Typography.P className="text-xs text-primary/70">IP Address</Typography.P>
             </div>
             <div className="overflow-hidden bg-secondary/30 px-2 py-1">
-              <Typography.P className="break-all text-xs font-mono text-primary/90">{ipInfo?.ip ?? "Detecting…"}</Typography.P>
+              <Typography.P className="break-all font-mono text-xs text-primary/90">{ipInfo?.ip ?? "Detecting…"}</Typography.P>
             </div>
           </div>
 
@@ -100,8 +100,8 @@ export default function VisitorPanel() {
               <MdDevices size={14} className="text-primary/60" />
               <Typography.P className="text-xs text-primary/70">Browser</Typography.P>
             </div>
-            <div className="bg-secondary/30 rounded px-2 py-1">
-              <Typography.P className="text-xs text-primary/90 truncate">{ua ? getBrowserInfo(ua) : "Detecting…"}</Typography.P>
+            <div className="bg-secondary/30 px-2 py-1">
+              <Typography.P className="truncate text-xs text-primary/90">{ua ? getBrowserInfo(ua) : "Detecting…"}</Typography.P>
             </div>
           </div>
 
@@ -110,17 +110,16 @@ export default function VisitorPanel() {
               <MdLocationOn size={14} className="text-primary/60" />
               <Typography.P className="text-xs text-primary/70">Location</Typography.P>
             </div>
-            <div className="bg-secondary/30 rounded px-2 py-1">
+            <div className="bg-secondary/30 px-2 py-1">
               <Typography.P className="text-xs text-primary/90">{locationLabel}</Typography.P>
             </div>
           </div>
         </div>
-      </div>
+      </Surface>
 
-      {/* Status */}
-      <div className="bg-secondary/20 rounded-lg p-4 border border-border/30">
-        <div className="flex items-center gap-2 mb-3">
-          <div className="w-2 h-2 rounded-full bg-green-500" />
+      <Surface variant="inset" padding="compact">
+        <div className="mb-3 flex items-center gap-2">
+          <div className="h-2 w-2 rounded-full bg-green-500" />
           <Typography.P className="text-sm font-semibold text-primary/80">Status</Typography.P>
         </div>
 
@@ -135,15 +134,14 @@ export default function VisitorPanel() {
           </div>
         </div>
 
-        <div className="mt-3 p-2 bg-green-500/10 rounded-lg border border-green-500/20">
-          <Typography.P className="text-xs text-green-600 dark:text-green-400">🚀 Open to opportunities</Typography.P>
+        <div className="mt-3 rounded-lg border border-green-500/20 bg-green-500/10 p-2">
+          <Typography.P className="text-xs text-green-600 dark:text-green-400">Open to opportunities</Typography.P>
         </div>
-      </div>
+      </Surface>
 
-      {/* Weather */}
-      <div className="bg-secondary/20 rounded-lg p-4 border border-border/30">
-        <div className="flex items-center gap-2 mb-3">
-          <BiGlobe size={16} className="text-orange-500" />
+      <Surface variant="inset" padding="compact">
+        <div className="mb-3 flex items-center gap-2">
+          <BiGlobe size={16} className="text-muted-foreground" />
           <Typography.P className="text-sm font-semibold text-primary/80">Weather</Typography.P>
         </div>
 
@@ -157,7 +155,7 @@ export default function VisitorPanel() {
               </div>
             </div>
             <div className="text-right">
-              <Typography.P className="text-xs text-primary/70 capitalize">{cond?.description ?? "Unknown"}</Typography.P>
+              <Typography.P className="text-xs capitalize text-primary/70">{cond?.description ?? "Unknown"}</Typography.P>
               <Typography.P className="text-xs text-primary/60">{feelsLike !== null ? `Feels like ${feelsLike}°` : ""}</Typography.P>
               {weather.main?.humidity != null && <Typography.P className="text-xs text-primary/60">Humidity {weather.main.humidity}%</Typography.P>}
             </div>
@@ -167,7 +165,7 @@ export default function VisitorPanel() {
             <Typography.P className="text-xs text-primary/60">Detecting your local weather…</Typography.P>
           </div>
         )}
-      </div>
+      </Surface>
     </>
   )
 }

--- a/src/components/ui/bento.tsx
+++ b/src/components/ui/bento.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils"
+import { SURFACE, SURFACE_PADDING } from "@/lib/design-system"
 
 export function BentoGrid({ className, children }: Readonly<{ className?: string; children: React.ReactNode }>) {
   return <div className={cn("grid grid-cols-1 gap-4 md:grid-cols-3", className)}>{children}</div>
@@ -17,14 +18,18 @@ interface FeatureCardProps {
 }
 
 /**
- * Hairline-bordered feature card with a small icon top-left. Compose inside
+ * Hairline-bordered solid feature card with a small icon top-left. Compose inside
  * <BentoGrid>; mark one card `large` for the Sapa 1-large + N-small layout.
+ * Prefer this over inventing another bordered box for feature/platform grids.
  */
 export function FeatureCard({ icon, title, accent, description, large, className, children }: Readonly<FeatureCardProps>) {
   return (
     <div
       className={cn(
-        "group flex flex-col gap-3 rounded-xl border border-border bg-card p-6 transition-colors hover:border-foreground/20",
+        "group flex flex-col gap-3",
+        SURFACE.solid,
+        SURFACE.solidHover,
+        SURFACE_PADDING.default,
         large && "md:row-span-2 md:justify-between",
         className,
       )}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { forwardRef, type HTMLAttributes } from "react"
 
 import { cn } from "@/lib/utils"
 import { SURFACE } from "@/lib/design-system"
@@ -7,71 +7,38 @@ import { SURFACE } from "@/lib/design-system"
  * Default solid content box. Do not override with glass classes
  * (`bg-white/5`, `backdrop-blur-md`, `border-white/10`) — use MacWindow / Surface variant="glass" for chrome.
  */
-const Card = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(SURFACE.solid, className)}
-    {...props}
-  />
+const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn(SURFACE.solid, className)} {...props} />
 ))
 Card.displayName = "Card"
 
-const CardHeader = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
-    {...props}
-  />
+/** Header region for a Card (`p-6` stack). */
+const CardHeader = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
 ))
 CardHeader.displayName = "CardHeader"
 
-const CardTitle = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("font-semibold leading-none tracking-tight", className)}
-    {...props}
-  />
+/** Title text inside a CardHeader. */
+const CardTitle = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("font-semibold leading-none tracking-tight", className)} {...props} />
 ))
 CardTitle.displayName = "CardTitle"
 
-const CardDescription = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
+/** Muted description text inside a CardHeader. */
+const CardDescription = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
 ))
 CardDescription.displayName = "CardDescription"
 
-const CardContent = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
+/** Main body of a Card (`p-6 pt-0`). */
+const CardContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
   <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 
-const CardFooter = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
-    {...props}
-  />
+/** Footer actions region for a Card. */
+const CardFooter = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
 ))
 CardFooter.displayName = "CardFooter"
 

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,17 +1,19 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { SURFACE } from "@/lib/design-system"
 
+/**
+ * Default solid content box. Do not override with glass classes
+ * (`bg-white/5`, `backdrop-blur-md`, `border-white/10`) — use MacWindow / Surface variant="glass" for chrome.
+ */
 const Card = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn(
-      "rounded-xl border border-border bg-card text-card-foreground shadow-sm transition-colors",
-      className
-    )}
+    className={cn(SURFACE.solid, className)}
     {...props}
   />
 ))

--- a/src/components/ui/mac-window.tsx
+++ b/src/components/ui/mac-window.tsx
@@ -1,20 +1,35 @@
 import { cn } from "@/lib/utils"
+import { SURFACE } from "@/lib/design-system"
 
 interface MacWindowProps {
   title?: string
   children: React.ReactNode
   className?: string
   bodyClassName?: string
+  /**
+   * When false, omits backdrop-blur so drag-and-drop libs that use
+   * `position: fixed` (e.g. @hello-pangea/dnd) are not offset by a
+   * filter-containing ancestor.
+   */
+  backdrop?: boolean
 }
 
 /**
  * macOS-style window chrome: a title bar with traffic-light dots and an optional
  * centered mono title, wrapping arbitrary content. Intentionally avoids
  * `overflow-hidden` so `position: sticky` children (e.g. the tools sidebar) keep working.
+ *
+ * Glass surface only — do not use for solid content cards (use Card / Surface / FeatureCard).
  */
-export function MacWindow({ title, children, className, bodyClassName }: Readonly<MacWindowProps>) {
+export function MacWindow({
+  title,
+  children,
+  className,
+  bodyClassName,
+  backdrop = true,
+}: Readonly<MacWindowProps>) {
   return (
-    <div className={cn("rounded-2xl border border-border/60 bg-background/40 shadow-sm backdrop-blur-sm", className)}>
+    <div className={cn(backdrop ? SURFACE.glass : SURFACE.glassNoBlur, className)}>
       <div className="flex items-center gap-3 rounded-t-2xl border-b border-border/60 bg-muted/40 px-4 py-3">
         <div className="flex items-center gap-1.5">
           <span className="h-3 w-3 rounded-full bg-red-400/90" />

--- a/src/components/ui/page-body.tsx
+++ b/src/components/ui/page-body.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import { PAGE_WIDTH, type PageWidth } from "@/lib/design-system"
+
+interface PageBodyProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Content width preset.
+   * - default: trust BaseLayout container (no nested max-w / extra px)
+   * - prose: max-w-3xl (articles / long-form)
+   * - article: max-w-5xl (project detail, changelog)
+   * - wide: max-w-7xl (roadmap grids)
+   */
+  width?: PageWidth
+}
+
+/**
+ * Width wrapper for page content inside BaseLayout.
+ * Do not add extra `px-4` / `lg:px-0` — BaseLayout already pads the container.
+ */
+export function PageBody({ width = "default", className, children, ...props }: Readonly<PageBodyProps>) {
+  return (
+    <div className={cn(PAGE_WIDTH[width], "flex flex-col gap-6", className)} {...props}>
+      {children}
+    </div>
+  )
+}
+
+export default PageBody

--- a/src/components/ui/page-body.tsx
+++ b/src/components/ui/page-body.tsx
@@ -1,9 +1,9 @@
-import * as React from "react"
+import type { HTMLAttributes } from "react"
 
 import { cn } from "@/lib/utils"
 import { PAGE_WIDTH, type PageWidth } from "@/lib/design-system"
 
-interface PageBodyProps extends React.HTMLAttributes<HTMLDivElement> {
+interface PageBodyProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Content width preset.
    * - default: trust BaseLayout container (no nested max-w / extra px)

--- a/src/components/ui/page-section.tsx
+++ b/src/components/ui/page-section.tsx
@@ -1,14 +1,15 @@
-import * as React from "react"
+import type { ComponentProps, HTMLAttributes, ReactNode } from "react"
 
 import { cn } from "@/lib/utils"
 import { SECTION_SPACING } from "@/lib/design-system"
 import { SectionHeading } from "@/components/ui/section-heading"
 
-interface PageSectionProps extends React.HTMLAttributes<HTMLElement> {
+interface PageSectionProps extends HTMLAttributes<HTMLElement> {
   /** Optional section heading props — when set, renders SectionHeading above children. */
-  heading?: React.ComponentProps<typeof SectionHeading>
+  heading?: ComponentProps<typeof SectionHeading>
   /** Spacing between heading and content. Defaults to mt-6. */
   contentClassName?: string
+  children?: ReactNode
 }
 
 /**

--- a/src/components/ui/page-section.tsx
+++ b/src/components/ui/page-section.tsx
@@ -1,0 +1,35 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import { SECTION_SPACING } from "@/lib/design-system"
+import { SectionHeading } from "@/components/ui/section-heading"
+
+interface PageSectionProps extends React.HTMLAttributes<HTMLElement> {
+  /** Optional section heading props — when set, renders SectionHeading above children. */
+  heading?: React.ComponentProps<typeof SectionHeading>
+  /** Spacing between heading and content. Defaults to mt-6. */
+  contentClassName?: string
+}
+
+/**
+ * Standard page/home section: mt-10 rhythm + optional SectionHeading.
+ * Use this instead of repeating `div.mt-10` + SectionHeading.
+ */
+export function PageSection({
+  heading,
+  children,
+  className,
+  contentClassName,
+  ...props
+}: Readonly<PageSectionProps>) {
+  return (
+    <section className={cn(SECTION_SPACING.section, className)} {...props}>
+      {heading && <SectionHeading {...heading} />}
+      {children && (
+        <div className={cn(heading ? SECTION_SPACING.sectionGap : undefined, contentClassName)}>{children}</div>
+      )}
+    </section>
+  )
+}
+
+export default PageSection

--- a/src/components/ui/surface.tsx
+++ b/src/components/ui/surface.tsx
@@ -1,9 +1,15 @@
-import * as React from "react"
+import {
+  forwardRef,
+  type HTMLAttributes,
+} from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 import { SURFACE, SURFACE_PADDING } from "@/lib/design-system"
 
+/**
+ * CVA variants for the three surface dialects (solid / glass / inset).
+ */
 const surfaceVariants = cva("", {
   variants: {
     variant: {
@@ -26,14 +32,14 @@ const surfaceVariants = cva("", {
 })
 
 export interface SurfaceProps
-  extends React.HTMLAttributes<HTMLDivElement>,
+  extends HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof surfaceVariants> {}
 
 /**
  * Canonical content box. Prefer this (or Card / FeatureCard / MacWindow) over
  * ad-hoc bordered divs. Variants map to the three allowed surface dialects.
  */
-export const Surface = React.forwardRef<HTMLDivElement, SurfaceProps>(
+export const Surface = forwardRef<HTMLDivElement, SurfaceProps>(
   ({ className, variant, padding, ...props }, ref) => (
     <div ref={ref} className={cn(surfaceVariants({ variant, padding }), className)} {...props} />
   ),

--- a/src/components/ui/surface.tsx
+++ b/src/components/ui/surface.tsx
@@ -1,0 +1,43 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { SURFACE, SURFACE_PADDING } from "@/lib/design-system"
+
+const surfaceVariants = cva("", {
+  variants: {
+    variant: {
+      solid: cn(SURFACE.solid, SURFACE.solidHover),
+      glass: SURFACE.glass,
+      "glass-static": SURFACE.glassNoBlur,
+      inset: SURFACE.inset,
+    },
+    padding: {
+      none: "",
+      default: SURFACE_PADDING.default,
+      compact: SURFACE_PADDING.compact,
+      cozy: SURFACE_PADDING.cozy,
+    },
+  },
+  defaultVariants: {
+    variant: "solid",
+    padding: "none",
+  },
+})
+
+export interface SurfaceProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof surfaceVariants> {}
+
+/**
+ * Canonical content box. Prefer this (or Card / FeatureCard / MacWindow) over
+ * ad-hoc bordered divs. Variants map to the three allowed surface dialects.
+ */
+export const Surface = React.forwardRef<HTMLDivElement, SurfaceProps>(
+  ({ className, variant, padding, ...props }, ref) => (
+    <div ref={ref} className={cn(surfaceVariants({ variant, padding }), className)} {...props} />
+  ),
+)
+Surface.displayName = "Surface"
+
+export { surfaceVariants }

--- a/src/lib/design-system.ts
+++ b/src/lib/design-system.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared design-system class tokens for Portfolio v3.
+ *
+ * Three surface dialects only — do not invent ad-hoc glass/solid blends:
+ * - solid:  default content boxes (Card / FeatureCard)
+ * - glass:  window chrome only (MacWindow, right-sidebar shell)
+ * - inset:  nested rows, sidebar blocks, status cells
+ */
+
+export const SURFACE = {
+  solid:
+    "rounded-xl border border-border bg-card text-card-foreground shadow-sm transition-colors",
+  solidHover: "hover:border-foreground/20",
+  glass:
+    "rounded-2xl border border-border/60 bg-background/40 shadow-sm backdrop-blur-sm",
+  glassNoBlur: "rounded-2xl border border-border/60 bg-background/40 shadow-sm",
+  inset: "rounded-lg border border-border/40 bg-secondary/20",
+} as const
+
+/** Default content padding for solid cards and feature boxes. */
+export const SURFACE_PADDING = {
+  default: "p-6",
+  compact: "p-4",
+  cozy: "p-5",
+} as const
+
+/** Section spacing used by PageSection / home blocks. */
+export const SECTION_SPACING = {
+  section: "mt-10",
+  sectionGap: "mt-6",
+} as const
+
+/**
+ * Content width presets for PageBody.
+ * Prefer `default` inside BaseLayout (trust the container).
+ */
+export const PAGE_WIDTH = {
+  default: "w-full",
+  prose: "mx-auto w-full max-w-3xl",
+  article: "mx-auto w-full max-w-5xl",
+  wide: "mx-auto w-full max-w-7xl",
+} as const
+
+export type SurfaceVariant = keyof typeof SURFACE
+export type PageWidth = keyof typeof PAGE_WIDTH


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Unifies Portfolio v3 content boxes onto one solid/glass/inset surface system, documents it for every AI platform, and gets DeepSource JavaScript green.

## Why

Components had drifted into several dialects. Agents had no shared layout rule. DeepSource JavaScript was failing on this PR (JS-0415 nesting, JS-C1003 wildcard imports, JS-0339 non-null assertions, JS-0440 dangerous HTML).

## Changes

### UI system (code)
- Added `src/lib/design-system.ts` surface/width/spacing tokens
- Added primitives: `Surface`, `PageSection`, `PageBody`; `MacWindow` gains `backdrop` prop
- Fixed BaseLayout double horizontal padding
- Migrated glass content cards → solid; ad-hoc boxes → Surface
- Unified blog/project media card hover to `hover:border-foreground/20`

### Agent + UI docs
- `AGENTS.md`, `GEMINI.md`, synced Claude/Cursor/Gemini/Copilot instructions
- Full UI docs under `docs/ui/`

### DeepSource
- Flattened JSX nesting via extracted card/status helpers (JS-0415)
- Named/type React imports instead of `import * as React` (JS-C1003)
- Removed non-null assertions (JS-0339)
- List card previews render plain text instead of `dangerouslySetInnerHTML` (JS-0440)
- Tuned `.deepsource.toml` for Next.js/React

## Status

DeepSource: JavaScript — **pass**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6c8d-ae7e-7253-af52-8662115e0e61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6c8d-ae7e-7253-af52-8662115e0e61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

