### PR TITLE
feat: load Umami session replay/heatmap recorder script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,10 @@ UMAMI_API_KEY=
 # UMAMI_PASSWORD=your-umami-password
 # NEXT_PUBLIC_UMAMI_SRC=http://localhost:3010/script.js
 # NEXT_PUBLIC_UMAMI_WEBSITE_ID=your-self-hosted-website-id
+#
+# Session replay + heatmaps recorder (optional). Toggle "Replays" / "Heatmaps"
+# on for the website in the Umami dashboard first — this only loads the script.
+# NEXT_PUBLIC_UMAMI_RECORDER_SRC=http://localhost:3010/recorder.js
 
 # Spotify (widget + GET /api/spotify) — all three required at runtime
 # Scopes: user-read-currently-playing, user-read-recently-played

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -93,6 +93,17 @@ export default function RootLayout({
           data-website-id={process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID ?? "3344dd5c-2e88-4ae5-95f7-e142cdbff614"}
           strategy="afterInteractive"
         />
+        {/* Umami session replay + heatmaps recorder. Enabled per-site in the Umami
+            dashboard (Website settings → Replays & Heatmaps); this only loads the
+            recorder script so the toggle there takes effect. */}
+        {process.env.NEXT_PUBLIC_UMAMI_RECORDER_SRC && (
+          <Script
+            defer
+            src={process.env.NEXT_PUBLIC_UMAMI_RECORDER_SRC}
+            data-website-id={process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID ?? "3344dd5c-2e88-4ae5-95f7-e142cdbff614"}
+            strategy="afterInteractive"
+          />
+        )}
       </head>
       <body className={cn("bg-background font-sans antialiased mx-auto", fontVariables)}>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>


### PR DESCRIPTION
Adds the recorder.js script tag alongside the existing analytics script.js, gated behind an optional NEXT_PUBLIC_UMAMI_RECORDER_SRC env var so it's a no-op when unset. Replay/heatmap sampling, mask level, etc. remain controlled from the Umami dashboard.

- Recorder script only loads when NEXT_PUBLIC_UMAMI_RECORDER_SRC is set
- Same data-website-id as the existing analytics script
- Documented in .env.example

Verified with 	sc --noEmit and 
pm run build locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)