### PR TITLE
fix: markdown tables overflow viewport on mobile (blog, roadmap, changelog)

### DIFF
--- a/src/app/(visitor)/changelog/page.tsx
+++ b/src/app/(visitor)/changelog/page.tsx
@@ -4,6 +4,7 @@ import { getAllChangelogs } from "@/lib/mdx"
 import { AnimatedThemeToggler } from "@/components/ui/animated-theme-toggler"
 import { formatDate } from "@/commons/helpers"
 import { MDXRemote } from "next-mdx-remote/rsc"
+import remarkGfm from "remark-gfm"
 import { getMDXComponents } from "@/components/ui/changelog-mdx-component"
 import { Button } from "@/components/ui/button"
 import { Eyebrow } from "@/components/ui/eyebrow"
@@ -73,7 +74,11 @@ export default function ChangelogPage() {
                       </div>
 
                       <div className="prose dark:prose-invert max-w-none prose-headings:scroll-mt-8 prose-headings:font-semibold prose-a:no-underline prose-headings:tracking-tight prose-headings:text-balance prose-p:tracking-tight prose-p:text-balance">
-                        <MDXRemote source={content} components={components} />
+                        <MDXRemote
+                          source={content}
+                          components={components}
+                          options={{ mdxOptions: { remarkPlugins: [remarkGfm] } }}
+                        />
                       </div>
                     </div>
                   </div>

--- a/src/app/(visitor)/roadmap/[slug]/page.tsx
+++ b/src/app/(visitor)/roadmap/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Clock, BookOpen, ArrowLeft, GraduationCap, Layers } from "lucide-react"
 import { getMDXComponents } from "@/components/ui/roadmap-mdx-component"
 import { MDXRemote } from "next-mdx-remote/rsc"
+import remarkGfm from "remark-gfm"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
@@ -100,7 +101,11 @@ export default async function RoadmapLessonPage({ params }: { params: Promise<{ 
 
           {/* MDX Content */}
           <article className="prose prose-neutral dark:prose-invert max-w-none prose-headings:scroll-mt-20 prose-h2:text-2xl prose-h2:font-bold prose-h2:font-display prose-h2:border-b prose-h2:pb-3 prose-h2:mt-12 prose-h2:mb-5 prose-h3:text-xl prose-h3:font-semibold prose-h3:font-display prose-h3:mt-10 prose-h3:mb-4 prose-p:leading-relaxed prose-pre:bg-muted prose-pre:border prose-code:before:content-none prose-code:after:content-none">
-            <MDXRemote source={content} components={components} />
+            <MDXRemote
+              source={content}
+              components={components}
+              options={{ mdxOptions: { remarkPlugins: [remarkGfm] } }}
+            />
           </article>
 
           {/* Completion Action */}

--- a/src/components/ui/changelog-mdx-component.tsx
+++ b/src/components/ui/changelog-mdx-component.tsx
@@ -54,6 +54,14 @@ function Author({ id }: AuthorProps) {
   return <AuthorCard author={author} className="my-8" />;
 }
 
+// Table wrapper — prose doesn't add horizontal scroll on its own, so a wide
+// markdown table (many columns) would otherwise overflow the viewport on mobile.
+const Table = (props: React.ComponentProps<"table">) => (
+  <div className="my-6 w-full overflow-x-auto">
+    <table {...props} />
+  </div>
+);
+
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     img: ({ className, ...props }: React.ComponentProps<"img">) => (
@@ -62,6 +70,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     MediaViewer,
     ImageViewer,
     VideoViewer,
+    table: Table,
     Accordion,
     AccordionContent,
     AccordionItem,

--- a/src/components/ui/mdx-components.tsx
+++ b/src/components/ui/mdx-components.tsx
@@ -14,8 +14,8 @@ interface TableProps {
 }
 
 const Table = ({ children }: TableProps) => (
-  <div className="table-container">
-    <table className="table w-full">{children}</table>
+  <div className="my-4 w-full overflow-x-auto">
+    <table className="w-full">{children}</table>
   </div>
 );
 
@@ -57,6 +57,7 @@ const MDXComponent = ({ children }: MarkdownRendererProps) => {
         ),
         code: (props) => <CodeBlock {...props} />,
         blockquote: (props) => <Typography.quote {...props} />,
+        table: (props) => <Table {...(props as TableProps)} />,
         th: (props) => (
           <th className="border px-3 py-1 text-left dark:border-neutral-600">
             {props.children}

--- a/src/components/ui/roadmap-mdx-component.tsx
+++ b/src/components/ui/roadmap-mdx-component.tsx
@@ -238,6 +238,14 @@ const Warning = ({ title = "Warning", children }: WarningProps) => {
   )
 }
 
+// Table wrapper — prose doesn't add horizontal scroll on its own, so a wide
+// markdown table (many columns) would otherwise overflow the viewport on mobile.
+const Table = (props: React.ComponentProps<"table">) => (
+  <div className="my-6 w-full overflow-x-auto">
+    <table {...props} />
+  </div>
+)
+
 // Info Card
 interface InfoProps {
   title?: string
@@ -259,6 +267,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     img: ({ className, alt, ...props }: React.ComponentProps<"img">) => <img className={cn("rounded-md border", className)} alt={alt || ""} {...props} />,
     pre: Pre,
     code: CodeBlock,
+    table: Table,
     MediaViewer,
     ImageViewer,
     VideoViewer,


### PR DESCRIPTION
## Root causes found

Two real bugs were compounding on the same symptom (wide markdown tables poking outside the layout on small screens, exactly what was reported):

1. **Blog markdown renderer** (mdx-components.tsx) had a \Table\ wrapper component using a \	able-container\ CSS class that doesn't exist anywhere in \globals.css\ — AND the component was never wired into the \ReactMarkdown\ \components\ map. Dead code; tables rendered as bare \<table>\ with zero scroll affordance.
2. **Roadmap and changelog pages** render MDX through \
ext-mdx-remote\'s \MDXRemote\ without \emarkGfm\ — so GFM pipe-table syntax (\| a | b |\) was never parsed as an actual table, it fell through to a garbled paragraph of raw pipe characters. Confirmed live in a mobile-viewport (375px) browser session before/after.

## Fix

- Wire \emarkGfm\ into both \MDXRemote\ calls (roadmap, changelog)
- Add a \	able\ component override (\overflow-x-auto\ wrapper div) to the blog ReactMarkdown renderer, roadmap MDX components, and changelog MDX components — \prose\ alone does not add horizontal scroll to wide tables

## Verification

- \
px tsc --noEmit\ — clean
- \
pm run build\ — clean
- Manually loaded a roadmap lesson with a real markdown table at 375×812 viewport: table now renders correctly inside a scrollable wrapper, \document.documentElement.scrollWidth === clientWidth\ (no page-level overflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)