### PR TITLE
feat: Senior AI Engineer copy + square/mobile tool chips

### DIFF
--- a/prd/feature.md
+++ b/prd/feature.md
@@ -33,3 +33,33 @@ Unify Portfolio v3 UI so all boxes, sections, and page shells share one monochro
 ## 4. Out of Scope
 - Full Signal page restyle (documented outlier)
 - Admin shell redesign (keep separate; reuse solid surfaces)
+
+---
+
+## 5. Track — Senior AI Engineer copy + square/mobile UI
+
+### 5.1 Copy
+Promote visitor-facing title from “AI Engineer” to **Senior AI Engineer**. Keep Sarana AI, stack, and UMM credentials.
+
+- Centralize `JOB_TITLE = "Senior AI Engineer"` in `src/commons/constants/author.ts`
+- Point `authors.*.position` and `MetadataConstants.jobTitle` / page / OG titles at that constant
+- Update hero, about, SEO/chrome (layouts, JSON-LD, OG image, manifest, terminal `whoami`)
+- Leave Supabase career rows and admin dashboard copy unchanged
+
+### 5.2 Square chips (visitor tools + ask-resume)
+- Downloader platform selector: square `Button` (`default` / `outline`, `size="sm"`) — no `rounded-full` pills
+- Pokémon type tags and Star Wars `#id` overlay: square, not pills
+- Ask-resume sample prompts: square `Button` outline chips
+- Keep circular: avatars, status dots, Mac traffic lights, progress bars, switch thumbs, mobile FAB, spinners
+
+### 5.3 Mobile
+- Downloader: stack URL + Download (`flex-col sm:flex-row`); Download `w-full sm:w-auto`
+- Platform chips: `flex-wrap` + `min-w-0` so labels like “X (Twitter)” wrap instead of overflowing
+- Intro typing/socials: `min-w-0` / `flex-wrap`; StatStrip values wrap on small screens
+- Tools shell: keep 2-col mobile nav; MacWindow body `p-3` must not clip sticky search
+
+### 5.4 Out of scope (this track)
+- `/signal` marketing experiment
+- Admin login chrome
+- Terminal overlay visual chrome (copy only)
+- Career titles stored in Supabase

--- a/prd/progress.md
+++ b/prd/progress.md
@@ -1,21 +1,22 @@
 # Portfolio v3 - Progress Tracker
 
-*Last Updated: 2026-07-17 (UI layout consistency + DeepSource fixes; About Me refresh retained from main)*
+*Last Updated: 2026-08-13 (Senior AI Engineer copy + square/mobile UI pass)*
 
 ---
 
 ## Project Overview
-**Goal:** Keep the public portfolio accurate (AI Engineer positioning) and visually consistent (solid / glass / inset surfaces) so recruiters and agents see one coherent system.
-**Success Criteria:** About/Intro reflect Sarana AI role; all content boxes use shared layout primitives; AI platform docs + DeepSource stay green.
+**Goal:** Keep the public portfolio accurate (Senior AI Engineer positioning) and visually consistent (solid / glass / inset surfaces, square chips) so recruiters and agents see one coherent system on desktop and mobile.
+**Success Criteria:** About/Intro/SEO say Senior AI Engineer from `JOB_TITLE`; leftover pill controls on visitor tools are square; downloader and intro wrap cleanly on small screens.
 
 ---
 
 ## Progress Summary
 
 ### Overall Status: 100% Complete (current tracks)
-- **About Me refresh**: ✅ COMPLETED — AI Engineer @ Sarana AI copy on About + Intro
+- **About Me refresh**: ✅ COMPLETED — Senior AI Engineer @ Sarana AI copy on About + Intro + SEO
 - **UI layout consistency**: ✅ COMPLETED — shared surfaces, migrations, agent/UI docs
 - **DeepSource JavaScript**: ✅ COMPLETED — nesting / imports / HTML preview issues fixed
+- **Senior AI + square/mobile pass**: ✅ COMPLETED — `JOB_TITLE` constant, square tool chips, mobile wrap
 
 ---
 
@@ -23,15 +24,34 @@
 
 ### COMPLETED
 
-#### About Me (HR-ready AI Engineer)
-- ✅ **About section description** - COMPLETED (2026-07-16)
-  - Removed undergraduate and web/mobile-only framing
-  - New copy: AI Engineer at Sarana AI, production LLM/RAG/MCP/AWS, Next.js/Go/Python, UMM Informatics Cum Laude 3.91/4.00
+#### About Me (HR-ready Senior AI Engineer)
+- ✅ **About section description** - COMPLETED (2026-08-13)
+  - Lead-in uses `JOB_TITLE` (“Senior AI Engineer at Sarana AI…”)
+  - Production LLM/RAG/MCP/AWS, Next.js/Go/Python, UMM Informatics Cum Laude 3.91/4.00
   - File: `src/app/_components/about/index.tsx`
-- ✅ **Intro hero bio + roles** - COMPLETED (2026-07-16)
-  - Bio leads with LLMs, RAG, MCP, Sarana AI, Python/AWS/Next.js/Go
-  - Roles: `AI Engineer`, `Cloud Enthusiast`, `Full-Stack Builder`
+- ✅ **Intro hero bio + roles** - COMPLETED (2026-08-13)
+  - Roles / eyebrow / Focus stat / bio lead-in all read `JOB_TITLE`
   - File: `src/app/_components/intro/index.tsx`
+- ✅ **Centralized title constant** - COMPLETED (2026-08-13)
+  - `JOB_TITLE` in `src/commons/constants/author.ts`; `authors.*.position` points at it
+  - `MetadataConstants.jobTitle`, `pageTitle`, `ogTitle`, `ogPersonTitle`
+  - JSON-LD `jobTitle`, root layout titles, OG image route, manifest, terminal `whoami`
+  - Visitor/user/auth layout Open Graph titles use `MetadataConstants.ogPersonTitle`
+
+#### Square chips + mobile (visitor tools)
+- ✅ **Downloader** - COMPLETED (2026-08-13)
+  - Platform selector: square `Button` `size="sm"` (`default` vs `outline`), `flex-wrap` + `min-w-0`
+  - URL + Download stack on small screens (`flex-col sm:flex-row`); Download `w-full sm:w-auto`
+  - Error icon wrap: `Surface variant="inset"` (square); spinner stays `rounded-full`
+  - File: `src/app/(visitor)/tools/_components/downloader-tab.tsx`
+- ✅ **Tools pill tags** - COMPLETED (2026-08-13)
+  - Pokémon type tags: square (`rounded-none`); progress bars stay circular
+  - Star Wars `#id` overlay: square; rocket avatar circle unchanged
+  - Ask-resume sample prompts: square outline `Button`; mobile FAB stays circular
+- ✅ **Mobile wrap** - COMPLETED (2026-08-13)
+  - Intro typing row + socials: `min-w-0` / `flex-wrap`
+  - StatStrip: `min-w-0` + `break-words` so “Senior AI Engineer” wraps
+  - Tools aside: `min-w-0`; 2-col nav kept; MacWindow already avoids `overflow-hidden`
 
 #### UI Layout Consistency
 - ✅ Design tokens: `src/lib/design-system.ts`
@@ -50,16 +70,21 @@
 - Legal + changelog join BaseLayout or documented StandaloneLayout
 - Home sections gradually adopt `PageSection`
 
-### Out of scope (unchanged from About Me track)
-- Supabase career/education rows (DB-backed)
+### Out of scope (unchanged)
+- Supabase career/education rows (DB-backed titles)
 - Owner-profile API `about` field
-- Footer / terminal / metadata (already AI Engineer)
+- Admin dashboard copy
+- `/signal` marketing experiment
+- Terminal overlay visual chrome (copy only)
 
 ---
 
 ## Key Code Locations
+- **Job title constant:** `src/commons/constants/author.ts` (`JOB_TITLE`)
+- **Metadata:** `src/commons/constants/metadata.ts`
 - **About section:** `src/app/_components/about/index.tsx`
 - **Intro section:** `src/app/_components/intro/index.tsx`
+- **Downloader:** `src/app/(visitor)/tools/_components/downloader-tab.tsx`
 - **Tokens:** `src/lib/design-system.ts`
 - **Primitives:** `src/components/ui/surface.tsx`, `page-section.tsx`, `page-body.tsx`, `mac-window.tsx`
 - **Rule:** `.cursor/rules/ui-layout-consistency.mdc`

--- a/src/app/(authentication)/auth/layout.tsx
+++ b/src/app/(authentication)/auth/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
     url: MetadataConstants.openGraph.url,
   },
   openGraph: {
-    title: "Muhammad Rizky Haksono - AI Engineer",
+    title: MetadataConstants.ogPersonTitle,
     images: MetadataConstants.profile,
     url: MetadataConstants.openGraph.url,
     siteName: MetadataConstants.openGraph.siteName,

--- a/src/app/(user)/ai/layout.tsx
+++ b/src/app/(user)/ai/layout.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     url: MetadataConstants.openGraph.url,
   },
   openGraph: {
-    title: "Muhammad Rizky Haksono - AI Engineer",
+    title: MetadataConstants.ogPersonTitle,
     images: MetadataConstants.profile,
     url: MetadataConstants.openGraph.url,
     siteName: MetadataConstants.openGraph.siteName,

--- a/src/app/(user)/profile/edit/layout.tsx
+++ b/src/app/(user)/profile/edit/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
     url: MetadataConstants.openGraph.url,
   },
   openGraph: {
-    title: "Muhammad Rizky Haksono - AI Engineer",
+    title: MetadataConstants.ogPersonTitle,
     images: MetadataConstants.profile,
     url: MetadataConstants.openGraph.url,
     siteName: MetadataConstants.openGraph.siteName,

--- a/src/app/(user)/profile/layout.tsx
+++ b/src/app/(user)/profile/layout.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
     url: MetadataConstants.openGraph.url,
   },
   openGraph: {
-    title: "Muhammad Rizky Haksono - AI Engineer",
+    title: MetadataConstants.ogPersonTitle,
     images: MetadataConstants.profile,
     url: MetadataConstants.openGraph.url,
     siteName: MetadataConstants.openGraph.siteName,

--- a/src/app/(visitor)/blog/layout.tsx
+++ b/src/app/(visitor)/blog/layout.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
     url: MetadataConstants.openGraph.url,
   },
   openGraph: {
-    title: "Muhammad Rizky Haksono - AI Engineer",
+    title: MetadataConstants.ogPersonTitle,
     images: MetadataConstants.profile,
     url: MetadataConstants.openGraph.url,
     siteName: MetadataConstants.openGraph.siteName,

--- a/src/app/(visitor)/certificates/layout.tsx
+++ b/src/app/(visitor)/certificates/layout.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
     url: MetadataConstants.openGraph.url,
   },
   openGraph: {
-    title: "Muhammad Rizky Haksono - AI Engineer",
+    title: MetadataConstants.ogPersonTitle,
     images: MetadataConstants.profile,
     url: MetadataConstants.openGraph.url,
     siteName: MetadataConstants.openGraph.siteName,

--- a/src/app/(visitor)/chat/layout.tsx
+++ b/src/app/(visitor)/chat/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
     url: MetadataConstants.openGraph.url,
   },
   openGraph: {
-    title: "Muhammad Rizky Haksono - AI Engineer",
+    title: MetadataConstants.ogPersonTitle,
     images: MetadataConstants.profile,
     url: MetadataConstants.openGraph.url,
     siteName: MetadataConstants.openGraph.siteName,

--- a/src/app/(visitor)/project/layout.tsx
+++ b/src/app/(visitor)/project/layout.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
     url: MetadataConstants.openGraph.url,
   },
   openGraph: {
-    title: "Muhammad Rizky Haksono - AI Engineer",
+    title: MetadataConstants.ogPersonTitle,
     images: MetadataConstants.profile,
     url: MetadataConstants.openGraph.url,
     siteName: MetadataConstants.openGraph.siteName,

--- a/src/app/(visitor)/roadmap/[slug]/layout.tsx
+++ b/src/app/(visitor)/roadmap/[slug]/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
     url: MetadataConstants.openGraph.url,
   },
   openGraph: {
-    title: "Muhammad Rizky Haksono - AI Engineer",
+    title: MetadataConstants.ogPersonTitle,
     images: MetadataConstants.profile,
     url: MetadataConstants.openGraph.url,
     siteName: MetadataConstants.openGraph.siteName,

--- a/src/app/(visitor)/roadmap/layout.tsx
+++ b/src/app/(visitor)/roadmap/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
     url: MetadataConstants.openGraph.url,
   },
   openGraph: {
-    title: "Muhammad Rizky Haksono - AI Engineer",
+    title: MetadataConstants.ogPersonTitle,
     images: MetadataConstants.profile,
     url: MetadataConstants.openGraph.url,
     siteName: MetadataConstants.openGraph.siteName,

--- a/src/app/(visitor)/tools/_components/downloader-tab.tsx
+++ b/src/app/(visitor)/tools/_components/downloader-tab.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Download, Video, ImageIcon, Play, ExternalLink, Info, Copy, CheckCircle2 } from "lucide-react"
 import Image from "next/image"
+import { Surface } from "@/components/ui/surface"
 import type { DownloadResult, InstagramDownloadData } from "@/commons/types/tools"
 
 type Platform = "tiktok" | "facebook" | "instagram" | "youtube" | "twitter"
@@ -178,26 +179,29 @@ export function DownloaderTab() {
 
   return (
     <div className="space-y-6">
-      {/* Platform Selector - Horizontal Pills */}
-      <div className="flex flex-wrap gap-2">
+      <div className="flex min-w-0 flex-wrap gap-2">
         {PLATFORMS.map((platform) => {
           const PlatformIcon = platform.icon
           const isActive = activePlatform === platform.id
           return (
-            <button
+            <Button
               key={platform.id}
+              type="button"
+              size="sm"
+              variant={isActive ? "default" : "outline"}
+              aria-pressed={isActive}
               onClick={() => setActivePlatform(platform.id)}
-              className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-all ${isActive ? "bg-foreground text-background" : "bg-secondary/50 hover:bg-secondary text-foreground"}`}
+              className="min-w-0"
             >
               <PlatformIcon size={16} />
               {platform.name}
-            </button>
+            </Button>
           )
         })}
       </div>
 
       {/* Supported Formats */}
-      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+      <div className="flex min-w-0 flex-wrap items-center gap-2 text-sm text-muted-foreground">
         <span>Supports:</span>
         {currentPlatform.supportedFormats.map((format) => (
           <Badge key={format} variant="outline" className="text-xs">
@@ -208,9 +212,9 @@ export function DownloaderTab() {
 
       {/* Download Input */}
       <div className="space-y-3">
-        <div className="flex gap-2">
-          <Input placeholder={`Paste ${currentPlatform.name} URL here...`} value={url} onChange={(e) => setUrl(e.target.value)} className="flex-1" />
-          <Button onClick={handleDownload} disabled={!url.trim() || isLoading} className="px-6">
+        <div className="flex min-w-0 flex-col gap-2 sm:flex-row">
+          <Input placeholder={`Paste ${currentPlatform.name} URL here...`} value={url} onChange={(e) => setUrl(e.target.value)} className="min-w-0 w-full flex-1" />
+          <Button onClick={handleDownload} disabled={!url.trim() || isLoading} className="w-full px-6 sm:w-auto">
             {isLoading ? (
               <>
                 <div className="w-4 h-4 border-2 border-white dark:border-black border-t-transparent rounded-full animate-spin mr-2" />
@@ -326,9 +330,9 @@ export function DownloaderTab() {
             </CardContent>
           ) : (
             <CardContent className="flex flex-col items-center justify-center gap-3 py-10 text-center">
-              <div className="rounded-full bg-destructive/10 p-3">
+              <Surface variant="inset" className="p-3">
                 <Info className="h-6 w-6 text-destructive" />
-              </div>
+              </Surface>
               <p className="font-semibold">Download failed</p>
               <p className="max-w-sm text-sm text-muted-foreground">
                 {result.data.author || "Couldn't fetch this URL. Check the link and try again."}

--- a/src/app/(visitor)/tools/_components/pokemon-tab.tsx
+++ b/src/app/(visitor)/tools/_components/pokemon-tab.tsx
@@ -25,7 +25,7 @@ const STAT_LABELS: Record<string, string> = {
 }
 
 function TypeBadge({ type }: { type: string }) {
-  return <span className={cn("rounded-full px-2.5 py-0.5 text-xs font-medium capitalize text-white", TYPE_COLORS[type] ?? "bg-stone-400")}>{type}</span>
+  return <span className={cn("rounded-none px-2.5 py-0.5 text-xs font-medium capitalize text-white", TYPE_COLORS[type] ?? "bg-stone-400")}>{type}</span>
 }
 
 export function PokemonTab() {

--- a/src/app/(visitor)/tools/_components/starwars-tab.tsx
+++ b/src/app/(visitor)/tools/_components/starwars-tab.tsx
@@ -54,7 +54,7 @@ function Characters() {
                   ) : (
                     <div className="flex h-full w-full items-center justify-center"><User className="h-8 w-8 text-muted-foreground" /></div>
                   )}
-                  <span className="absolute right-1.5 top-1.5 rounded-full bg-black/60 px-1.5 py-0.5 text-[10px] font-medium text-white backdrop-blur-sm">#{p.id}</span>
+                  <span className="absolute right-1.5 top-1.5 rounded-none bg-black/60 px-1.5 py-0.5 text-[10px] font-medium text-white backdrop-blur-sm">#{p.id}</span>
                   <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/85 via-black/40 to-transparent p-2.5 pt-6">
                     <p className="truncate text-sm font-semibold text-white">{p.name}</p>
                     <p className="truncate text-[11px] capitalize text-white/70">{p.species !== "unknown" ? p.species : p.gender}</p>

--- a/src/app/(visitor)/tools/page.tsx
+++ b/src/app/(visitor)/tools/page.tsx
@@ -59,7 +59,7 @@ export default async function ToolsPage({ searchParams }: Readonly<ToolsPageProp
         {/* Sidebar nav + active tool content */}
         <MacWindow title="~/tools" bodyClassName="p-3 sm:p-5">
         <div className="flex flex-col gap-6 lg:flex-row">
-          <aside className="lg:w-60 lg:shrink-0">
+          <aside className="min-w-0 lg:w-60 lg:shrink-0">
             <div className="rounded-xl border border-border bg-card/40 p-3 lg:sticky lg:top-20">
               <ToolsBrowser activeTab={activeTab} />
             </div>

--- a/src/app/_components/about/index.tsx
+++ b/src/app/_components/about/index.tsx
@@ -7,6 +7,7 @@ import {
   PORTFOLIO_PDF_GOOGLE_DRIVE_URL,
   RESUME_GOOGLE_DRIVE_URL,
 } from "@/commons/constants/external-links"
+import { JOB_TITLE } from "@/commons/constants/author"
 
 export default function AboutSection() {
   return (
@@ -16,7 +17,7 @@ export default function AboutSection() {
           eyebrow="About"
           title="A little"
           accent="about me"
-          description="AI Engineer at Sarana AI building production LLM systems — RAG/embeddings, MCP integrations, and cloud-native agents on AWS. I ship end-to-end products with Next.js, Go, and Python that cut manual work and scale real business workflows. Informatics graduate from Universitas Muhammadiyah Malang (Cum Laude, 3.91/4.00)."
+          description={`${JOB_TITLE} at Sarana AI building production LLM systems — RAG/embeddings, MCP integrations, and cloud-native agents on AWS. I ship end-to-end products with Next.js, Go, and Python that cut manual work and scale real business workflows. Informatics graduate from Universitas Muhammadiyah Malang (Cum Laude, 3.91/4.00).`}
         />
         <div className="mt-6 flex flex-wrap gap-3">
           <Button asChild size="sm">

--- a/src/app/_components/ask-resume/ask-resume-launcher.tsx
+++ b/src/app/_components/ask-resume/ask-resume-launcher.tsx
@@ -184,18 +184,21 @@ export default function AskResumeLauncher() {
             </form>
 
             {!answer && !loading && (
-              <div className="mt-2.5 flex flex-wrap gap-1.5">
+              <div className="mt-2.5 flex min-w-0 flex-wrap gap-1.5">
                 {SAMPLES.map((s) => (
-                  <button
+                  <Button
                     key={s}
+                    type="button"
+                    variant="outline"
+                    size="sm"
                     onClick={() => {
                       setQ(s)
                       ask(s)
                     }}
-                    className="rounded-full border border-border/60 bg-background/60 px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:border-primary/40 hover:bg-muted hover:text-foreground"
+                    className="h-auto min-w-0 whitespace-normal px-2.5 py-1 text-xs text-muted-foreground"
                   >
                     {s}
-                  </button>
+                  </Button>
                 ))}
               </div>
             )}

--- a/src/app/_components/intro/index.tsx
+++ b/src/app/_components/intro/index.tsx
@@ -8,13 +8,14 @@ import { StatStrip } from "@/components/ui/stat-strip"
 import { Button } from "@/components/ui/button"
 import Typography from "@/components/ui/typography"
 import { media_socials } from "@/commons/constants/contact"
+import { JOB_TITLE } from "@/commons/constants/author"
 import { ArrowRight } from "lucide-react"
 import type { OwnerProfile } from "@/services/visitor/owner-profile"
 
-const roles = ["AI Engineer", "Cloud Enthusiast", "Full-Stack Builder"]
+const roles = [JOB_TITLE, "Cloud Enthusiast", "Full-Stack Builder"]
 
 const HERO_STATS = [
-  { label: "Focus", value: "AI Engineer" },
+  { label: "Focus", value: JOB_TITLE },
   { label: "Stack", value: "TS · Go" },
   { label: "Cloud", value: "AWS · Azure" },
   { label: "Based in", value: "Malang, ID" },
@@ -36,7 +37,7 @@ export default function IntroSection({ profile }: Readonly<{ profile?: OwnerProf
                 <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-70" />
                 <span className="relative inline-flex h-2 w-2 rounded-full bg-primary" />
               </span>
-              Open to work · AI Engineer
+              Open to work · {JOB_TITLE}
             </Eyebrow>
           </div>
 
@@ -50,16 +51,16 @@ export default function IntroSection({ profile }: Readonly<{ profile?: OwnerProf
 
           {/* Typing Animation for Roles */}
           <div className="animate-fade-in-up" style={{ animationDelay: "200ms" }}>
-            <div className="flex items-center gap-2 text-sm">
-              <span className="text-muted-foreground">I&apos;m a</span>
-              <TypingAnimation words={roles} className="font-semibold text-base md:text-lg text-primary" duration={120} pauseDelay={2500} loop showCursor cursorStyle="line" />
+            <div className="flex min-w-0 items-center gap-2 text-sm">
+              <span className="shrink-0 text-muted-foreground">I&apos;m a</span>
+              <TypingAnimation words={roles} className="min-w-0 font-semibold text-base md:text-lg text-primary" duration={120} pauseDelay={2500} loop showCursor cursorStyle="line" />
             </div>
           </div>
 
           {/* Bio Text */}
           <div className="animate-fade-in-up" style={{ animationDelay: "300ms" }}>
             <p className="max-w-xl text-xs sm:text-sm leading-relaxed text-muted-foreground">
-              Building production AI systems — <span className="font-medium text-foreground">LLMs, RAG, and MCP</span> — backed by full-stack and cloud engineering. At Sarana AI I ship scalable agents and data platforms with{" "}
+              {JOB_TITLE} building production AI systems — <span className="font-medium text-foreground">LLMs, RAG, and MCP</span> — backed by full-stack and cloud engineering. At Sarana AI I ship scalable agents and data platforms with{" "}
               <span className="font-medium text-foreground">Python, AWS, Next.js, and Go</span>, focused on reliable CI/CD and <Typography.Em>measurable</Typography.Em> impact.
             </p>
           </div>
@@ -81,7 +82,7 @@ export default function IntroSection({ profile }: Readonly<{ profile?: OwnerProf
 
           {/* Social Links */}
           <div className="animate-fade-in-up" style={{ animationDelay: "500ms" }}>
-            <div className="flex items-center gap-3">
+            <div className="flex min-w-0 flex-wrap items-center gap-3">
               <Eyebrow>Find me on</Eyebrow>
               <div className="flex flex-wrap gap-2 items-center">
                 {media_socials.map((social) => (
@@ -90,7 +91,7 @@ export default function IntroSection({ profile }: Readonly<{ profile?: OwnerProf
                     href={social.href}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="p-2.5 rounded-lg border border-border bg-background hover:bg-accent hover:text-primary transition-colors"
+                    className="rounded-lg border border-border bg-background p-2.5 transition-colors hover:border-foreground/20 hover:bg-accent hover:text-primary"
                     title={social.title}
                   >
                     <social.icon className="size-4" />

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from "next/og";
+import { JOB_TITLE } from "@/commons/constants/author";
 
 export const runtime = "edge";
 
@@ -59,7 +60,7 @@ export async function GET(request: Request) {
           </div>
           <div style={{ display: "flex", flexDirection: "column" }}>
             <span style={{ fontSize: 28, fontWeight: 700 }}>Rizky Haksono</span>
-            <span style={{ fontSize: 20, color: "#94a3b8" }}>AI Engineer</span>
+            <span style={{ fontSize: 20, color: "#94a3b8" }}>{JOB_TITLE}</span>
           </div>
           {label ? (
             <div

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -46,7 +46,7 @@ const fontMono = localFont({
 const fontVariables = cn(fontSans.variable, fontDisplay.variable, fontSerif.variable, fontMono.variable)
 
 export const metadata: Metadata = {
-  title: "Rizky Haksono | AI Engineer",
+  title: MetadataConstants.pageTitle,
   metadataBase: new URL(process.env.NODE_ENV === "development" ? "http://localhost:3000" : process.env.DOMAIN ?? ""),
   description: MetadataConstants.description,
   keywords: MetadataConstants.keyword,
@@ -56,7 +56,7 @@ export const metadata: Metadata = {
     url: MetadataConstants.openGraph.url,
   },
   openGraph: {
-    title: "Muhammad Rizky Haksono | AI Engineer",
+    title: MetadataConstants.ogTitle,
     images: MetadataConstants.profile,
     url: MetadataConstants.openGraph.url,
     siteName: MetadataConstants.openGraph.siteName,

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,10 +1,11 @@
 import { MetadataRoute } from "next";
+import { MetadataConstants } from "@/commons/constants/metadata";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "Muhammad Rizky Haksono - AI Engineer",
+    name: MetadataConstants.ogPersonTitle,
     short_name: "Rizky Haksono",
-    description: "Muhammad Rizky Haksono is an AI engineer who loves to build things.",
+    description: MetadataConstants.description,
     start_url: "/",
     display: "standalone",
     background_color: "#fff",

--- a/src/commons/constants/author.ts
+++ b/src/commons/constants/author.ts
@@ -1,3 +1,5 @@
+export const JOB_TITLE = "Senior AI Engineer"
+
 export interface Author {
   name: string;
   position: string;
@@ -7,12 +9,12 @@ export interface Author {
 export const authors: Record<string, Author> = {
   rizky: {
     name: "Muhammad Rizky Haksono",
-    position: "AI Engineer",
+    position: JOB_TITLE,
     avatar: "/rizky.jpg",
   },
   natee: {
     name: "rizkyhaksono",
-    position: "AI Engineer",
+    position: JOB_TITLE,
     avatar: "/rizky.jpg",
   },
 } as const;

--- a/src/commons/constants/metadata.ts
+++ b/src/commons/constants/metadata.ts
@@ -1,8 +1,13 @@
+import { JOB_TITLE } from "@/commons/constants/author"
+
 export const MetadataConstants = {
   creator: "Muhammad Rizky Haksono",
-  description:
-    "Muhammad Rizky Haksono is an AI engineer who loves to build things.",
-  keyword: "Muhammad Rizky Haksono, AI Engineer, machine learning, LLM, RAG, developer, frontend, backend, UI/UX",
+  jobTitle: JOB_TITLE,
+  description: `Muhammad Rizky Haksono is a ${JOB_TITLE} building production LLM systems — RAG, MCP, and cloud-native agents.`,
+  keyword: `Muhammad Rizky Haksono, ${JOB_TITLE}, machine learning, LLM, RAG, MCP, developer, frontend, backend, UI/UX`,
+  pageTitle: `Rizky Haksono | ${JOB_TITLE}`,
+  ogTitle: `Muhammad Rizky Haksono | ${JOB_TITLE}`,
+  ogPersonTitle: `Muhammad Rizky Haksono - ${JOB_TITLE}`,
   authors: {
     name: "Muhammad Rizky Haksono",
     url: process.env.DOMAIN,

--- a/src/components/seo/json-ld.tsx
+++ b/src/components/seo/json-ld.tsx
@@ -11,7 +11,7 @@ export default function JsonLd() {
     "@type": "Person",
     name: MetadataConstants.creator,
     url: siteUrl,
-    jobTitle: "AI Engineer",
+    jobTitle: MetadataConstants.jobTitle,
     sameAs: [
       MetadataConstants.openGraph.url,
       "https://github.com/rizkyhaksono",

--- a/src/components/ui/stat-strip.tsx
+++ b/src/components/ui/stat-strip.tsx
@@ -18,9 +18,9 @@ export function StatStrip({ items, className }: Readonly<StatStripProps>) {
   return (
     <dl className={cn("grid grid-cols-2 border-y border-border sm:grid-cols-4", className)}>
       {items.map((item) => (
-        <div key={item.label} className="flex flex-col gap-1 border-border px-4 py-5 [&:not(:last-child)]:border-r">
+        <div key={item.label} className="flex min-w-0 flex-col gap-1 border-border px-3 py-5 sm:px-4 [&:not(:last-child)]:border-r">
           <dt className="font-mono text-[11px] uppercase tracking-[0.15em] text-muted-foreground">{item.label}</dt>
-          <dd className="font-display text-2xl font-bold tracking-tight tabular-nums sm:text-3xl">{item.value}</dd>
+          <dd className="break-words font-display text-xl font-bold tracking-tight tabular-nums sm:text-2xl md:text-3xl">{item.value}</dd>
         </div>
       ))}
     </dl>

--- a/src/components/ui/terminal-overlay.tsx
+++ b/src/components/ui/terminal-overlay.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, useCallback } from "react"
 import { useRouter } from "next/navigation"
 import { useTheme } from "next-themes"
 import { cn } from "@/lib/utils"
+import { JOB_TITLE } from "@/commons/constants/author"
 
 type Line = { kind: "in" | "out"; text: string }
 
@@ -43,7 +44,7 @@ const COMMANDS: Command[] = [
   {
     name: "whoami",
     description: "About me",
-    run: () => ["Muhammad Rizky Haksono", "Software / AI Engineer — RAG, LLMs, multi-cloud.", "Type `socials` to connect, `open /project` to see my work."],
+    run: () => ["Muhammad Rizky Haksono", `${JOB_TITLE} — RAG, LLMs, multi-cloud.`, "Type `socials` to connect, `open /project` to see my work."],
   },
   {
     name: "ls",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Promote visitor-facing copy to Senior AI Engineer from a shared `JOB_TITLE` constant, and replace leftover pill controls on visitor tools with square chips that wrap on mobile.

## Why

Recruiters still saw “AI Engineer” in layouts/SEO while the hero was drifting, and the downloader platform selector (plus a few tool tags) was the last rounded-pill dialect on visitor pages.

## Changes

**Copy**
- Add `JOB_TITLE` in `src/commons/constants/author.ts` and wire `authors.*.position` plus metadata/OG/JSON-LD/manifest/terminal `whoami` to it
- Update About, Intro (roles, eyebrow, Focus stat, bio), and visitor/user/auth Open Graph titles
- Leave Supabase career rows and admin dashboard copy unchanged

**Square + mobile**
- Downloader: square `Button` platform toggles, stacked URL + Download on small screens, inset error icon (spinner stays circular)
- Pokémon type tags and Star Wars `#id` overlay: square
- Ask-resume sample prompts: square outline buttons; mobile FAB stays circular
- Intro typing/socials and StatStrip wrap with `min-w-0` / `break-words`

Out of scope: `/signal`, admin login chrome, terminal overlay visuals.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6c8d-ae7e-7253-af52-8662115e0e61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6c8d-ae7e-7253-af52-8662115e0e61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

