### PR TITLE
fix: GitHub contribution graph can scroll to newest weeks

### DIFF
--- a/prd/feature.md
+++ b/prd/feature.md
@@ -63,3 +63,13 @@ Promote visitor-facing title from “AI Engineer” to **Senior AI Engineer**. K
 - Admin login chrome
 - Terminal overlay visual chrome (copy only)
 - Career titles stored in Supabase
+
+---
+
+## 6. Track — GitHub contribution calendar overflow
+
+The home heatmap was clipped on the right (newest weeks) because the grid used `overflow-hidden` and `main` in a flex row lacked `min-w-0`.
+
+- Single `overflow-x-auto` scroller wrapping month labels + week columns (`w-max`, week columns `shrink-0`)
+- Default scroll position: newest week (right edge)
+- `main`/`flex` row: `min-w-0` so the scroller can actually shrink and scroll

--- a/prd/progress.md
+++ b/prd/progress.md
@@ -1,6 +1,6 @@
 # Portfolio v3 - Progress Tracker
 
-*Last Updated: 2026-08-13 (Senior AI Engineer copy + square/mobile UI pass)*
+*Last Updated: 2026-08-18 (GitHub contribution calendar horizontal scroll)*
 
 ---
 
@@ -17,6 +17,7 @@
 - **UI layout consistency**: ✅ COMPLETED — shared surfaces, migrations, agent/UI docs
 - **DeepSource JavaScript**: ✅ COMPLETED — nesting / imports / HTML preview issues fixed
 - **Senior AI + square/mobile pass**: ✅ COMPLETED — `JOB_TITLE` constant, square tool chips, mobile wrap
+- **GitHub contribution calendar overflow**: ✅ COMPLETED — heatmap scrolls horizontally; newest weeks visible
 
 ---
 
@@ -53,6 +54,13 @@
   - StatStrip: `min-w-0` + `break-words` so “Senior AI Engineer” wraps
   - Tools aside: `min-w-0`; 2-col nav kept; MacWindow already avoids `overflow-hidden`
 
+#### GitHub contribution calendar overflow
+- ✅ **Horizontal scroll + newest week** - COMPLETED (2026-08-18)
+  - Replaced `overflow-hidden` on month labels and week grid with one `overflow-x-auto` scroller (`w-max` inner, week columns `shrink-0`)
+  - `useLayoutEffect` pins `scrollLeft` to the right so the current streak is visible on mobile
+  - `BaseLayout` main + flex row get `min-w-0` so the heatmap can shrink instead of being clipped
+  - Files: `src/app/_components/contribution/github-calender.tsx`, `src/components/layout/base-layout.tsx`
+
 #### UI Layout Consistency
 - ✅ Design tokens: `src/lib/design-system.ts`
 - ✅ Primitives: `surface.tsx`, `page-section.tsx`, `page-body.tsx`
@@ -85,6 +93,7 @@
 - **About section:** `src/app/_components/about/index.tsx`
 - **Intro section:** `src/app/_components/intro/index.tsx`
 - **Downloader:** `src/app/(visitor)/tools/_components/downloader-tab.tsx`
+- **GitHub calendar:** `src/app/_components/contribution/github-calender.tsx`
 - **Tokens:** `src/lib/design-system.ts`
 - **Primitives:** `src/components/ui/surface.tsx`, `page-section.tsx`, `page-body.tsx`, `mac-window.tsx`
 - **Rule:** `.cursor/rules/ui-layout-consistency.mdc`

--- a/src/app/_components/contribution/github-calender.tsx
+++ b/src/app/_components/contribution/github-calender.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { cn } from "@/lib/utils"
-import { useState } from "react"
+import { useLayoutEffect, useRef, useState } from "react"
 
 interface Contribution {
   date: string
@@ -27,7 +27,21 @@ interface GithubCalendarProps {
   }
 }
 
+const CELL_SIZE_PX = 12
+const CELL_GAP_PX = 3
+const WEEK_COLUMN_PX = CELL_SIZE_PX + CELL_GAP_PX
+
+/**
+ * Pins the heatmap to the newest week so mobile viewports show the current
+ * streak first; older months remain reachable by scrolling left.
+ */
+const scrollToNewestWeek = (node: HTMLDivElement | null) => {
+  if (!node) return
+  node.scrollLeft = node.scrollWidth
+}
+
 const GithubCalendar = ({ data }: GithubCalendarProps) => {
+  const scrollRef = useRef<HTMLDivElement>(null)
   const [selectContribution, setSelectContribution] = useState<{
     count: number | null
     date: string | null
@@ -53,48 +67,63 @@ const GithubCalendar = ({ data }: GithubCalendarProps) => {
 
   const contributionColors = data?.colors ?? []
 
+  useLayoutEffect(() => {
+    scrollToNewestWeek(scrollRef.current)
+  }, [weeks.length])
+
   return (
     <>
-      <div className="relative flex flex-col">
-        <ul className="flex justify-end gap-[3px] overflow-hidden text-xs dark:text-neutral-400 md:justify-start">
-          {months.map((month) => (
-            <li key={month.firstDay} className={cn(`${month.totalWeeks < 2 ? "invisible" : ""}`)} style={{ minWidth: 14.3 * month.totalWeeks }}>
-              {month.name}
-            </li>
-          ))}
-        </ul>
+      <div
+        ref={scrollRef}
+        tabIndex={0}
+        aria-label="GitHub contribution calendar"
+        className="w-full min-w-0 overflow-x-auto overscroll-x-contain pb-1"
+      >
+        <div className="flex w-max min-w-full flex-col">
+          <ul className="flex gap-[3px] text-xs text-muted-foreground">
+            {months.map((month) => (
+              <li
+                key={month.firstDay}
+                className={cn(month.totalWeeks < 2 && "invisible")}
+                style={{ minWidth: WEEK_COLUMN_PX * month.totalWeeks }}
+              >
+                {month.name}
+              </li>
+            ))}
+          </ul>
 
-        <div className="flex justify-start gap-[3px] overflow-hidden">
-          {weeks?.map((week) => (
-            <div key={week.firstDay}>
-              {week.contributionDays.map((contribution) => {
-                const backgroundColor = contribution.contributionCount > 0 && contribution.color
+          <div className="flex gap-[3px] py-0.5">
+            {weeks.map((week) => (
+              <div key={week.firstDay} className="flex w-[12px] shrink-0 flex-col">
+                {week.contributionDays.map((contribution) => {
+                  const backgroundColor = contribution.contributionCount > 0 && contribution.color
 
-                return (
-                  <span
-                    key={contribution.date}
-                    className="my-[2px] block h-[12px] w-[12px] rounded-sm bg-neutral-300 dark:bg-neutral-800 transition-transform duration-150 hover:scale-125"
-                    style={backgroundColor ? { backgroundColor } : undefined}
-                    onMouseEnter={() =>
-                      setSelectContribution({
-                        count: contribution.contributionCount,
-                        date: contribution.date,
-                      })
-                    }
-                    onMouseLeave={() => setSelectContribution({ count: null, date: null })}
-                  />
-                )
-              })}
-            </div>
-          ))}
+                  return (
+                    <span
+                      key={contribution.date}
+                      className="my-[2px] block h-[12px] w-[12px] rounded-sm bg-muted transition-transform duration-150 hover:scale-125"
+                      style={backgroundColor ? { backgroundColor } : undefined}
+                      onMouseEnter={() =>
+                        setSelectContribution({
+                          count: contribution.contributionCount,
+                          date: contribution.date,
+                        })
+                      }
+                      onMouseLeave={() => setSelectContribution({ count: null, date: null })}
+                    />
+                  )
+                })}
+              </div>
+            ))}
+          </div>
         </div>
       </div>
 
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2 text-sm">
-          <span className="dark:text-neutral-400">Less</span>
+          <span className="text-muted-foreground">Less</span>
           <ul className="flex gap-1">
-            <li className="h-[10px] w-[10px] rounded-sm bg-neutral-300 dark:bg-neutral-800" />
+            <li className="h-[10px] w-[10px] rounded-sm bg-muted" />
             {contributionColors.map((item) => (
               <li key={item} className="h-[10px] w-[10px] rounded-sm" style={{ backgroundColor: item }} />
             ))}
@@ -102,7 +131,12 @@ const GithubCalendar = ({ data }: GithubCalendarProps) => {
           <span>More</span>
         </div>
 
-        <div className={cn(`${selectContribution?.date ? "opacity-100" : "opacity-0"}`, "rounded bg-neutral-200 px-2 text-sm dark:bg-neutral-700 transition-opacity duration-200")}>
+        <div
+          className={cn(
+            selectContribution?.date ? "opacity-100" : "opacity-0",
+            "rounded-md bg-muted px-2 text-sm transition-opacity duration-200",
+          )}
+        >
           {selectContribution?.count} contributions on {selectContribution?.date}
         </div>
       </div>

--- a/src/components/layout/base-layout.tsx
+++ b/src/components/layout/base-layout.tsx
@@ -42,9 +42,9 @@ export default async function BaseLayout({
         <div className="block md:hidden">
           <Navbar isHaveToken={isHaveToken} />
         </div>
-        <div className="flex md:gap-6">
+        <div className="flex min-w-0 md:gap-6">
           {sidebar && <aside>{sidebar}</aside>}
-          <main className="mb-16 pt-4 w-full overflow-hidden">{children}</main>
+          <main className="mb-16 min-w-0 w-full overflow-x-clip pt-4">{children}</main>
           {rightSidebar && <aside className="hidden md:block">{rightSidebar}</aside>}
         </div>
         <Footer />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Stop clipping the home GitHub contribution heatmap so the newest weeks are reachable via horizontal scroll (and shown first on mobile).

## Why

The graph used `overflow-hidden` on both month labels and week columns, and `main` in the flex page shell had no `min-w-0`. The latest squares were cut off on the right, and there was no scrollbar to get to them.

## Changes

- Wrap month labels + week cells in one `overflow-x-auto` scroller (`w-max` inner row, week columns `shrink-0`)
- Pin `scrollLeft` to the right on layout so the current streak is visible on small screens (scroll left for older months)
- Give the BaseLayout flex row and `main` `min-w-0` so the scroller can shrink instead of being clipped
- Swap leftover `neutral-*` classes on this calendar for semantic tokens while touching the file

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6c8d-ae7e-7253-af52-8662115e0e61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6c8d-ae7e-7253-af52-8662115e0e61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

